### PR TITLE
Docker for CPU build, Calculate last registered time for crossed vehicle in realtime

### DIFF
--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -1,0 +1,103 @@
+# docker run --rm -it \
+#       -v "$(pwd)/data/conf.toml:/app/data/conf.toml" \
+#       -v "$(pwd)/data/4K_Video_of_Highway_Traffic.mp4:/app/data/4K_Video_of_Highway_Traffic.mp4" \
+#       -v "$(pwd)/data/yolov4.weights:/app/data/yolov4.weights" \
+#       -v "$(pwd)/data/yolov4.cfg:/app/data/yolov4.cfg" \
+#       -e CONFIG_PATH=/app/data/conf.toml \
+#       -p 42001:42001 \
+#       rust_road_traffic-app
+
+FROM ubuntu:22.04 AS build_opencv
+
+# Timezone prompt
+ENV TZ=Etc/UTC
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
+ARG OPENCV_VERSION="4.7.0"
+ENV OPENCV_VERSION $OPENCV_VERSION
+
+RUN apt-get update && \
+  apt-get install -y --no-install-recommends \
+  unzip wget build-essential cmake curl git libgtk2.0-dev pkg-config libavcodec-dev libavformat-dev libswscale-dev libtbb2 libtbb-dev libjpeg-dev libpng-dev libtiff-dev libdc1394-dev \
+  ffmpeg \
+  libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev libgstreamer-plugins-bad1.0-dev gstreamer1.0-plugins-base gstreamer1.0-plugins-good gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly gstreamer1.0-libav gstreamer1.0-tools gstreamer1.0-x gstreamer1.0-alsa gstreamer1.0-gl gstreamer1.0-gtk3 gstreamer1.0-qt5 gstreamer1.0-pulseaudio \
+  ca-certificates \
+  clang libclang-dev
+
+
+RUN curl https://sh.rustup.rs -sSf | bash -s -- -y
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+ARG OPENCV_FILE="https://github.com/opencv/opencv/archive/${OPENCV_VERSION}.zip"
+ENV OPENCV_FILE $OPENCV_FILE
+
+ARG OPENCV_CONTRIB_FILE="https://github.com/opencv/opencv_contrib/archive/${OPENCV_VERSION}.zip"
+ENV OPENCV_CONTRIB_FILE $OPENCV_CONTRIB_FILE
+
+RUN wget -O opencv.zip ${OPENCV_FILE} && unzip -q opencv.zip && \
+    wget -O opencv_contrib.zip ${OPENCV_CONTRIB_FILE} && unzip -q opencv_contrib.zip && \
+    rm opencv.zip opencv_contrib.zip
+
+# It is essential to make static libs instead of dynamic one
+RUN cd opencv-${OPENCV_VERSION} && \
+      mkdir build && cd build && \
+      cmake \
+      -D CMAKE_BUILD_TYPE=RELEASE \
+      -D CMAKE_INSTALL_PREFIX=/usr/local \
+      -D OPENCV_EXTRA_MODULES_PATH=../../opencv_contrib-${OPENCV_VERSION}/modules \
+      -D OPENCV_GENERATE_PKGCONFIG=ON \
+      -D WITH_IPP=OFF \
+      -D WITH_OPENGL=OFF \
+      -D WITH_QT=OFF \
+      -D OPENCV_ENABLE_NONFREE=ON \
+      -D WITH_JASPER=OFF \
+      -D WITH_TBB=ON \
+      -D BUILD_JPEG=ON \
+      -D WITH_SIMD=ON \
+      -D ENABLE_LIBJPEG_TURBO_SIMD=ON \
+      -D BUILD_DOCS=OFF \
+      -D BUILD_EXAMPLES=OFF \
+      -D BUILD_TESTS=OFF \
+      -D BUILD_PERF_TESTS=ON \
+      -D BUILD_opencv_java=NO \
+      -D BUILD_opencv_python=NO \
+      -D BUILD_opencv_python2=NO \
+      -D BUILD_opencv_python3=NO \
+      .. && \
+      make -j $(nproc --all) && \
+      make install && \
+      ldconfig && \
+      cd / && rm -rf opencv*
+
+WORKDIR /build_app
+COPY ./Cargo.lock ./Cargo.lock
+COPY ./Cargo.toml ./Cargo.toml
+COPY ./build.rs ./build.rs
+COPY ./src ./src
+
+# static
+# ENV OPENCV_LINK_LIBS=opencv_gapi,opencv_highgui,opencv_objdetect,opencv_dnn,opencv_videostab,opencv_calib3d,opencv_features2d,opencv_stitching,opencv_flann,opencv_videoio,opencv_rgbd,opencv_aruco,opencv_video,opencv_ml,opencv_imgcodecs,opencv_imgproc,opencv_core,ade,ittnotify,tbb,liblibwebp,liblibtiff,liblibjpeg-turbo,liblibpng,liblibopenjp2,ippiw,ippicv,liblibprotobuf,quirc,zlib
+# ENV OPENCV_LINK_PATHS=/opt/opencv/lib,/opt/opencv/lib/opencv4/3rdparty,/usr/lib/x86_64-linux-gnu
+# ENV OPENCV_INCLUDE_PATHS=/opt/opencv/include/opencv4
+RUN cargo build --release
+
+# ENTRYPOINT cat /opt/opencv/include/opencv4/opencv2/core/version.hpp 
+# ENTRYPOINT pkg-config --modversion opencv4
+# https://www.h3manth.com/content/copying-shared-library-dependencies
+RUN ldd target/release/rust-road-traffic | awk 'BEGIN{ORS=" "}$1 ~/^\//{print $1}$3~/^\//{print $3}' | sed 's/,$/\n/' > /build_app/shared_libs_list.txt
+# Copy shared libs from root of system to the build folder
+RUN mkdir /build_app/shared_libs && for lib in $(cat shared_libs_list.txt); do \
+  mkdir -p /build_app/shared_libs/$(dirname $lib); \
+  cp -v $lib /build_app/shared_libs/$lib; \
+  done
+
+FROM alpine
+COPY --from=build_opencv /build_app/target/release/rust-road-traffic /app/rust-road-traffic
+# Copy shared libs to the root of system
+COPY --from=build_opencv /build_app/shared_libs /
+WORKDIR /app
+RUN mkdir /app/data
+ENV LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/usr/local/lib
+ENV CONFIG_PATH=conf.toml
+ENTRYPOINT ./rust-road-traffic $CONFIG_PATH
+

--- a/src/lib/zones/zones.rs
+++ b/src/lib/zones/zones.rs
@@ -54,6 +54,8 @@ pub struct Zone {
 #[derive(Debug)]
 pub struct RealTimeStatistics {
     pub last_time: u64,
+    pub last_time_relative: f32,
+    pub last_time_registered: f32,
     pub occupancy: u16,
 }
 
@@ -72,6 +74,8 @@ impl Zone {
             objects_registered: HashMap::new(),
             current_statistics: RealTimeStatistics {
                 last_time: 0,
+                last_time_relative: 0.0,
+                last_time_registered: 0.0,
                 occupancy: 0,
             },
             skeleton: Skeleton::default(),
@@ -120,6 +124,8 @@ impl Zone {
             objects_registered: HashMap::new(),
             current_statistics: RealTimeStatistics {
                 last_time: 0,
+                last_time_relative: 0.0,
+                last_time_registered: 0.0,
                 occupancy: 0,
             },
             skeleton: skeleton,
@@ -262,6 +268,7 @@ impl Zone {
         &mut self,
         object_id: Uuid,
         _timestamp: f32,
+        _relative_time: f32,
         _speed: f32,
         _classname: String,
         _crossed_virtual_line: bool,
@@ -280,6 +287,7 @@ impl Zone {
                 }
             }
             Vacant(entry) => {
+                self.current_statistics.last_time_registered = _relative_time;
                 entry.insert(ObjectInfo {
                     classname: _classname,
                     speed: _speed,

--- a/src/main.rs
+++ b/src/main.rs
@@ -412,7 +412,7 @@ fn run(settings: &AppSettings, path_to_config: &str, tracker: &mut Tracker, neur
         );
 
         let relative_time = received.overall_seconds;
-        match tracker.match_objects(&mut tmp_detections, received.current_second) {
+        match tracker.match_objects(&mut tmp_detections, relative_time) {
             Ok(_) => {},
             Err(err) => {
                 println!("Can't match objects due the error: {:?}", err);

--- a/src/rest_api/zones_stats.rs
+++ b/src/rest_api/zones_stats.rs
@@ -150,6 +150,13 @@ pub struct ZoneRealtime {
     /// Last time occupancy calculated. Unix Timestamp (seconds)
     #[schema(example = 1693386819)]
     pub last_time: u64,
+    /// Time spent since video has been started. It is relative to FPS
+    #[schema(example = 12.9)]
+    pub last_time_relative: f32,
+    /// Last time (spent since software has been started) when vehicle has been registered is zone (via crossing virtual line
+    /// or appearing in zone) calculated. Measure in seconds.
+    #[schema(example = 10.2)]
+    pub last_time_registered: f32,
     /// Occupancy
     #[schema(example = 3)]
     pub occupancy: u16,
@@ -182,6 +189,8 @@ pub async fn all_zones_occupancy(data: web::Data<APIStorage>) -> Result<HttpResp
             lane_number: zone.road_lane_num,
             lane_direction: zone.road_lane_direction,
             last_time: zone.current_statistics.last_time,
+            last_time_relative: zone.current_statistics.last_time_relative,
+            last_time_registered: zone.current_statistics.last_time_registered,
             occupancy: zone.current_statistics.occupancy,
         };
         ans.data.push(stats);

--- a/src/video_capture/frame.rs
+++ b/src/video_capture/frame.rs
@@ -9,5 +9,6 @@ use chrono::{
 
 pub struct ThreadedFrame {
     pub frame: Mat,
+    pub overall_seconds: f32,
     pub current_second: f32
 }


### PR DESCRIPTION
- Added Dockerfile for CPU #23 
- Make use of overall seconds spent in video (relative to FPS)
- Prepare two new fields for realtime api (`api/realtime/occupancy`): 
  - last_time_relative - Time spent since video has been started. It is relative to FPS
  - last_time_registered - Last time (spent since software has been started) when vehicle has been registered is zone (via crossing virtual line or appearing in zone) calculated. Measure in seconds.