### PR TITLE
[BREAKING] Compile software without OpenCV at all

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 /data/yolov4-tiny_custom.cfg
 /data/yolov4-tiny_custom.names
 /data/yolov4-tiny_custom.weights
+/data/yolov4-tiny-vehicles-rect.onnx
+/data/yolov4-tiny-vehicles-rect.engine
 /data/video.mp4
 /data/sample-2_960_540.mp4
 /data/yolov4.cfg

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2626,6 +2626,7 @@ dependencies = [
  "futures",
  "mot-rs",
  "nalgebra",
+ "ndarray",
  "od_opencv",
  "opencv",
  "png",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2033,9 +2033,9 @@ checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
 name = "od_opencv"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8efa4773ff9ed76d3087baa4b7999cef0f48f183a2cac897e0dec19cd100a192"
+checksum = "61947cc7ea03ab5bd2713c56e8a1aedc93379904f7b50c9a51ef9e34e1dd99cf"
 dependencies = [
  "image",
  "lazy_static",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,19 +12,21 @@ path = "src/main.rs"
 [features]
 default = ["opencv-backend"]
 # Use OpenCV DNN for inference (default)
-opencv-backend = ["opencv/dnn", "od_opencv/opencv-backend"]
-# Use ONNX Runtime for inference (no OpenCV DNN to avoid conflicts)
-ort-backend = ["od_opencv/ort-backend", "od_opencv/ort-opencv-compat"]
+opencv-backend = ["dep:opencv", "opencv/dnn", "od_opencv/opencv-backend"]
+# Use ONNX Runtime for inference (no OpenCV dependency)
+ort-backend = ["od_opencv/ort-backend"]
 # CUDA acceleration for ORT backend
 ort-cuda = ["ort-backend", "od_opencv/ort-cuda-backend"]
-# TensorRT backend (Jetson Nano, NVIDIA GPUs with .engine files)
-tensorrt-backend = ["od_opencv/tensorrt-opencv-compat"]
+# TensorRT backend (Jetson Nano, NVIDIA GPUs with .engine files, no OpenCV dependency)
+tensorrt-backend = ["od_opencv/tensorrt-backend"]
 # Build libjpeg-turbo from source via cmake (no system lib needed)
 turbojpeg-vendor = ["turbojpeg/cmake"]
 
 [dependencies]
-# OpenCV: only core::Mat for inference boundary. DNN feature is conditional via features above
-opencv = { version = "0.96.0", default-features = false, features = [] }
+# OpenCV: only needed for opencv-backend (DNN inference). Optional for ort/tensorrt backends.
+opencv = { version = "0.96.0", default-features = false, features = [], optional = true }
+# ndarray: RawFrame => ImageBuffer conversion for ort/tensorrt backends
+ndarray = "0.17"
 uuid = { version = "1.18.1", features = ["serde", "v4"] }
 nalgebra = "0.34.1"
 toml = "0.9.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ mot-rs = "0.5.0"
 utoipa = { version = "3", features = ["actix_extras"] }
 utoipa-rapidoc = { version = "0.1", features = ["actix-web"] }
 # Object detection with YOLO models
-od_opencv = { version = "0.8.1", default-features = false, features = ["letterbox"] }
+od_opencv = { version = "0.8.2", default-features = false, features = ["letterbox"] }
 rand = "0.9.2"
 zip = { version = "2", default-features = false, features = ["deflate"] }
 # JPEG encoding for MJPEG streaming (libjpeg-turbo).

--- a/README.md
+++ b/README.md
@@ -36,13 +36,15 @@ This project supports three inference backends via compile-time feature flags:
 
 | Backend | Feature Flag | Models Supported | GPU Support | Requires OpenCV |
 |---------|--------------|------------------|-------------|-----------------|
-| OpenCV DNN | `opencv-backend` (default) | YOLOv8/v9/v11 (ONNX) | CUDA, OpenCL | Yes |
+| OpenCV DNN | `opencv-backend` (default) | YOLOv3/v4/v7 (Darknet), YOLOv8/v9/v11 (ONNX) | CUDA, OpenCL | Yes |
 | ONNX Runtime | `ort-backend` | YOLOv8/v9/v11 (ONNX only) | CUDA 12.x | No |
 | TensorRT | `tensorrt-backend` | YOLOv8/v9/v11 (`.engine` only) | CUDA (native TensorRT) | No |
 
 **`ort-backend` and `tensorrt-backend` do NOT require OpenCV** on the system. Video capture uses ffmpeg/GStreamer subprocesses, drawing uses own primitives, image encoding uses [`turbojpeg`](https://github.com/libjpeg-turbo/libjpeg-turbo)/[`png`](https://github.com/image-rs/image-png) crates.
 
 **`tensorrt-backend`** is designed for NVIDIA embedded platforms (e.g. Jetson Nano) and discrete NVIDIA GPUs with TensorRT installed.
+
+**Network input size:** For Darknet models (`.cfg` + `.weights`), `net_width`/`net_height` in TOML config are **ignored** - the input size is read directly from the `[net]` section of the `.cfg` file. For ONNX and TensorRT models, `net_width`/`net_height` must be specified in the TOML config.
 
 **Note:** In case of non-OpenCV backend, traditional models (YOLOv3/v4/v7) in Darknet format (`.cfg` + `.weights`) should be converted to ONNX first via [darknet2onnx](https://github.com/LdDl/darknet2onnx) with `--format yolov8` flag. The `--format yolov5` output is **not supported** (different post-processing). For TensorRT, convert ONNX to `.engine` via `trtexec`.
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ This project supports three inference backends via compile-time feature flags:
 
 **`tensorrt-backend`** is designed for NVIDIA embedded platforms (e.g. Jetson Nano) and discrete NVIDIA GPUs with TensorRT installed.
 
-**Network input size:** For Darknet models (`.cfg` + `.weights`), `net_width`/`net_height` in TOML config are **ignored** - the input size is read directly from the `[net]` section of the `.cfg` file. For ONNX and TensorRT models, `net_width`/`net_height` must be specified in the TOML config.
+**Network input size:** For Darknet models (`.cfg` + `.weights`), `net_width`/`net_height` in TOML config are __ignored__ - the input size is read directly from the `[net]` section of the `.cfg` file. For TensorRT (`.engine`), input size is also auto-detected from the engine bindings. For ONNX models, `net_width`/`net_height` must be specified in the TOML config.
 
 **Note:** In case of non-OpenCV backend, traditional models (YOLOv3/v4/v7) in Darknet format (`.cfg` + `.weights`) should be converted to ONNX first via [darknet2onnx](https://github.com/LdDl/darknet2onnx) with `--format yolov8` flag. The `--format yolov5` output is **not supported** (different post-processing). For TensorRT, convert ONNX to `.engine` via `trtexec`.
 

--- a/README.md
+++ b/README.md
@@ -32,39 +32,38 @@ UI is developed in seprate repository: https://github.com/LdDl/rust-road-traffic
 
 ## Inference Backends
 
-This project supports two inference backends via compile-time feature flags:
+This project supports three inference backends via compile-time feature flags:
 
-| Backend | Feature Flag | Models Supported | GPU Support |
-|---------|--------------|------------------|-------------|
-| OpenCV DNN | `opencv-backend` (default) | YOLOv3/v4/v7 (Darknet), YOLOv8/v9/v11 (ONNX) | CUDA, OpenCL |
-| ONNX Runtime | `ort-backend` | YOLOv8/v9/v11 (ONNX only) | CUDA 12.x |
-| TensorRT | `tensorrt-backend` | YOLOv3/v4/v7/v8/v9/v11 (`.engine` only) | CUDA (native TensorRT) |
+| Backend | Feature Flag | Models Supported | GPU Support | Requires OpenCV |
+|---------|--------------|------------------|-------------|-----------------|
+| OpenCV DNN | `opencv-backend` (default) | YOLOv8/v9/v11 (ONNX) | CUDA, OpenCL | Yes |
+| ONNX Runtime | `ort-backend` | YOLOv8/v9/v11 (ONNX only) | CUDA 12.x | No |
+| TensorRT | `tensorrt-backend` | YOLOv8/v9/v11 (`.engine` only) | CUDA (native TensorRT) | No |
 
-**How `ort-backend` works:** Uses ONNX Runtime for inference but still requires OpenCV for video I/O, drawing, and preprocessing. This is achieved via the `ort-opencv-compat` adapter from `od_opencv` crate, which allows ORT models to accept OpenCV `Mat` directly without enabling OpenCV's DNN module (avoiding static linking conflicts).
+**`ort-backend` and `tensorrt-backend` do NOT require OpenCV** on the system. Video capture uses ffmpeg/GStreamer subprocesses, drawing uses own primitives, image encoding uses [`turbojpeg`](https://github.com/libjpeg-turbo/libjpeg-turbo)/[`png`](https://github.com/image-rs/image-png) crates.
 
-**How `tensorrt-backend` works:** Uses NVIDIA TensorRT for inference via serialized `.engine` files. Still requires OpenCV for video I/O, drawing, and preprocessing (via `tensorrt-opencv-compat` adapter from `od_opencv` crate). This backend is designed for NVIDIA embedded platforms (Jetson Nano, Jetson Xavier, Jetson Orin) and discrete NVIDIA GPUs.
+**`tensorrt-backend`** is designed for NVIDIA embedded platforms (e.g. Jetson Nano) and discrete NVIDIA GPUs with TensorRT installed.
 
-**Important:**
-- The `ort-backend` does NOT support Darknet weights (`.cfg` + `.weights` files). If you need YOLOv3/v4/v7 with Darknet format, use `opencv-backend`.
-- The `tensorrt-backend` ONLY supports `.engine` files. You must convert your model to TensorRT engine format beforehand (e.g. via `trtexec`). Darknet (`.cfg` + `.weights`) and ONNX (`.onnx`) files will NOT work with this backend.
+**Note:** In case of non-OpenCV backend, traditional models (YOLOv3/v4/v7) in Darknet format (`.cfg` + `.weights`) should be converted to ONNX first via [darknet2onnx](https://github.com/LdDl/darknet2onnx) with `--format yolov8` flag. The `--format yolov5` output is **not supported** (different post-processing). For TensorRT, convert ONNX to `.engine` via `trtexec`.
 
 ### Build Commands
 
 By default MJPEG streaming links to system `libturbojpeg` via `pkg-config`. Add `--features turbojpeg-vendor` to any build command below to build libjpeg-turbo from source instead (requires `cmake`).
 
 ```bash
-# OpenCV backend (default) - supports all YOLO versions
+# OpenCV backend (default) - requires OpenCV installed, supports traditional and Ultralytics models
 cargo build --release
 
-# ORT backend - YOLOv8/v9/v11 ONNX only
+# ORT backend - no OpenCV needed at all
 cargo build --release --no-default-features --features ort-backend
 
-# TensorRT backend - YOLOv3/v4/v7/v8/v9/v11 .engine only (Jetson / NVIDIA GPU)
+# TensorRT backend - no OpenCV needed at all (Jetson / NVIDIA GPU)
 cargo build --release --no-default-features --features tensorrt-backend
 
 # Any backend + vendored libjpeg-turbo (no system lib needed, requires cmake)
 cargo build --release --features turbojpeg-vendor
 cargo build --release --no-default-features --features tensorrt-backend,turbojpeg-vendor
+cargo build --release --no-default-features --features ort-backend,turbojpeg-vendor
 ```
 
 ### Run Commands
@@ -90,7 +89,7 @@ trtexec --onnx=yolov8n.onnx --saveEngine=yolov8n.engine --fp16
 
 On Jetson devices, `trtexec` is typically located at `/usr/src/tensorrt/bin/trtexec`.
 
-Be aware that Traditional models `v3`, `v4` and `v7` should be converted to ONNX first via [darknet2onnx](https://github.com/LdDl/darknet2onnx) and then via `trtexec` to TensorRT engine format.
+Be aware that Traditional models `v3`, `v4` and `v7` should be converted to ONNX first via [darknet2onnx](https://github.com/LdDl/darknet2onnx) with `--format yolov8` flag, and then via `trtexec` to TensorRT engine format.
 
 ## Traffic flow parameters
 
@@ -148,7 +147,8 @@ Locally you can access Swagger UI documentation via http://localhost:42001/api/d
 ## Installation and usage
 1. You need installed Rust compiler obviously. Follow instruction of official site: https://www.rust-lang.org/tools/install
 
-2. You need installed OpenCV and its contributors modules. I'm using OpenCV 4.7.0. I'd highly recommend to use OpenCV with CUDA. Here is [Makefile](Makefile) adopted from [this one](https://github.com/hybridgroup/gocv/blob/release/Makefile) if you want build it from sources (it's targeted for Linux user obviously).
+2. **OpenCV** is only required for `opencv-backend` (the default). If you use `ort-backend` or `tensorrt-backend`, skip this step.
+    I'm using OpenCV 4.7.0. In case of need `opencv-backend` I'd highly recommend to use OpenCV with CUDA. Here is [Makefile](Makefile) adopted from [this one](https://github.com/hybridgroup/gocv/blob/release/Makefile) if you want build it from sources (it's targeted for Linux user obviously).
     ```shell
     sudo make install_cuda
     ```
@@ -187,7 +187,7 @@ Locally you can access Swagger UI documentation via http://localhost:42001/api/d
     video_src = "v4l2src device=/dev/video0 ! video/x-raw, width=(int)640, height=(int)480, framerate=(fraction)30/1, format=(string)BGR ! appsink"
     ```
 
-4. OpenCV's bindings have already meant as dependencies in [Cargo.toml](Cargo.toml)
+4. Dependencies are managed via [Cargo.toml](Cargo.toml). OpenCV bindings are pulled automatically when using `opencv-backend`.
 
 5. Clone the repo
     ```shell

--- a/data/conf.toml
+++ b/data/conf.toml
@@ -12,12 +12,8 @@
     enable = true
 
 [detection]
-    # Available model_versions: v3, v4, v7, v8
-    # Default is v3
-    network_ver = 7
-    # Available model formats: "darknet", "onnx"
-    # Default is "darknet"
-    network_format = "darknet"
+    # Weights file: .weights (Darknet), .onnx (ONNX), .engine/.trt (TensorRT)
+    # Format is auto-detected from file contents + extension
     network_weights = "./data/yolov7.weights"
     network_cfg = "./data/yolov7.cfg"
     conf_threshold = 0.4

--- a/data/conf2.toml
+++ b/data/conf2.toml
@@ -12,12 +12,8 @@
     enable = true
 
 [detection]
-    # Available model_versions: v3, v4, v7, v8
-    # Default is v3
-    network_ver = 7
-    # Available model formats: "darknet", "onnx"
-    # Default is "darknet"
-    network_format = "darknet"
+    # Weights file: .weights (Darknet), .onnx (ONNX), .engine/.trt (TensorRT)
+    # Format is auto-detected from file contents + extension
     network_weights = "./data/yolov7.weights"
     network_cfg = "./data/yolov7.cfg"
     conf_threshold = 0.4

--- a/src/lib/detection/detector.rs
+++ b/src/lib/detection/detector.rs
@@ -157,12 +157,17 @@ impl Detector {
         not(feature = "opencv-backend"),
         not(feature = "ort-backend")
     ))]
-    pub fn new(weights: &str, net_size: (i32, i32), _network_cfg: Option<&str>) -> Self {
+    pub fn new(weights: &str, _net_size: (i32, i32), _network_cfg: Option<&str>) -> Self {
         println!("Using TensorRT backend");
-        println!("TensorRT network input size: {}x{}", net_size.0, net_size.1);
-        let net_size_u32 = (net_size.0 as u32, net_size.1 as u32);
-        match Model::tensorrt(weights, net_size_u32) {
-            Ok(model) => Detector::TensorRT(model),
+        match Model::tensorrt(weights) {
+            Ok(model) => {
+                let (w, h) = model.input_size();
+                println!(
+                    "TensorRT network input size: {}x{} (from engine)",
+                    w, h
+                );
+                Detector::TensorRT(model)
+            }
             Err(err) => panic!(
                 "Can't create TensorRT model '{}' due the error: {:?}",
                 weights, err

--- a/src/lib/detection/detector.rs
+++ b/src/lib/detection/detector.rs
@@ -34,7 +34,7 @@ pub enum Detector {
 
 impl Detector {
     #[cfg(feature = "opencv-backend")]
-    pub fn new(weights: &str, net_size: (i32, i32), network_cfg: Option<&str>) -> Self {
+    pub fn new(weights: &str, net_size: Option<(i32, i32)>, network_cfg: Option<&str>) -> Self {
         let cuda_available = utils::is_cuda_available();
         println!(
             "CUDA is {}",
@@ -91,6 +91,12 @@ impl Detector {
                 }
             }
             utils::ModelFileFormat::Onnx => {
+                let net_size = net_size.unwrap_or_else(|| {
+                    panic!(
+                        "ONNX model '{}' requires net_width/net_height in config.",
+                        weights
+                    )
+                });
                 println!(
                     "OpenCV ONNX network input size: {}x{}",
                     net_size.0, net_size.1
@@ -112,7 +118,7 @@ impl Detector {
     }
 
     #[cfg(all(feature = "ort-backend", not(feature = "opencv-backend")))]
-    pub fn new(weights: &str, net_size: (i32, i32), _network_cfg: Option<&str>) -> Self {
+    pub fn new(weights: &str, net_size: Option<(i32, i32)>, _network_cfg: Option<&str>) -> Self {
         let cuda_available = utils::is_cuda_available();
         println!(
             "CUDA is {}",
@@ -129,6 +135,12 @@ impl Detector {
         let backend_name = "CPU";
 
         println!("Using ORT backend ({})", backend_name);
+        let net_size = net_size.unwrap_or_else(|| {
+            panic!(
+                "ONNX model '{}' requires net_width/net_height in config.",
+                weights
+            )
+        });
         println!("ORT ONNX network input size: {}x{}", net_size.0, net_size.1);
 
         let net_size_u32 = (net_size.0 as u32, net_size.1 as u32);
@@ -157,7 +169,7 @@ impl Detector {
         not(feature = "opencv-backend"),
         not(feature = "ort-backend")
     ))]
-    pub fn new(weights: &str, _net_size: (i32, i32), _network_cfg: Option<&str>) -> Self {
+    pub fn new(weights: &str, _net_size: Option<(i32, i32)>, _network_cfg: Option<&str>) -> Self {
         println!("Using TensorRT backend");
         match Model::tensorrt(weights) {
             Ok(model) => {

--- a/src/lib/detection/detector.rs
+++ b/src/lib/detection/detector.rs
@@ -72,7 +72,17 @@ impl Detector {
                         weights
                     )
                 });
-                match Model::darknet(cfg, weights, net_size, dnn_backend, dnn_target) {
+                let cfg_net_size = utils::parse_darknet_cfg_net_size(cfg).unwrap_or_else(|e| {
+                    panic!(
+                        "Can't parse net_size from '{}': {}. Provide width/height in [net] section.",
+                        cfg, e
+                    )
+                });
+                println!(
+                    "OpenCV Darknet network input size: {}x{} (from {})",
+                    cfg_net_size.0, cfg_net_size.1, cfg
+                );
+                match Model::darknet(cfg, weights, cfg_net_size, dnn_backend, dnn_target) {
                     Ok(model) => Box::new(model),
                     Err(err) => panic!(
                         "Can't read Darknet network '{}' / '{}' due the error: {:?}",
@@ -81,6 +91,10 @@ impl Detector {
                 }
             }
             utils::ModelFileFormat::Onnx => {
+                println!(
+                    "OpenCV ONNX network input size: {}x{}",
+                    net_size.0, net_size.1
+                );
                 match Model::opencv(weights, net_size, dnn_backend, dnn_target) {
                     Ok(model) => Box::new(model),
                     Err(err) => panic!(
@@ -115,6 +129,7 @@ impl Detector {
         let backend_name = "CPU";
 
         println!("Using ORT backend ({})", backend_name);
+        println!("ORT ONNX network input size: {}x{}", net_size.0, net_size.1);
 
         let net_size_u32 = (net_size.0 as u32, net_size.1 as u32);
 
@@ -144,6 +159,7 @@ impl Detector {
     ))]
     pub fn new(weights: &str, net_size: (i32, i32), _network_cfg: Option<&str>) -> Self {
         println!("Using TensorRT backend");
+        println!("TensorRT network input size: {}x{}", net_size.0, net_size.1);
         let net_size_u32 = (net_size.0 as u32, net_size.1 as u32);
         match Model::tensorrt(weights, net_size_u32) {
             Ok(model) => Detector::TensorRT(model),

--- a/src/lib/detection/detector.rs
+++ b/src/lib/detection/detector.rs
@@ -1,0 +1,229 @@
+use crate::lib::cv::RawFrame;
+use crate::lib::cv::Rect as RectCV;
+use crate::lib::utils;
+
+#[cfg(feature = "opencv-backend")]
+use od_opencv::{DnnBackend, DnnTarget, Model, model::ModelTrait};
+#[cfg(feature = "opencv-backend")]
+use opencv::{core::Mat, prelude::MatTraitManual};
+
+#[cfg(all(feature = "ort-backend", not(feature = "opencv-backend")))]
+use od_opencv::{Model, ModelUltralyticsOrt};
+
+#[cfg(all(
+    feature = "tensorrt-backend",
+    not(feature = "opencv-backend"),
+    not(feature = "ort-backend")
+))]
+use od_opencv::{Model, ModelUltralyticsRt};
+
+pub enum Detector {
+    #[cfg(feature = "opencv-backend")]
+    OpenCV(Box<dyn ModelTrait>),
+
+    #[cfg(all(feature = "ort-backend", not(feature = "opencv-backend")))]
+    Ort(ModelUltralyticsOrt),
+
+    #[cfg(all(
+        feature = "tensorrt-backend",
+        not(feature = "opencv-backend"),
+        not(feature = "ort-backend")
+    ))]
+    TensorRT(ModelUltralyticsRt),
+}
+
+impl Detector {
+    #[cfg(feature = "opencv-backend")]
+    pub fn new(weights: &str, net_size: (i32, i32), network_cfg: Option<&str>) -> Self {
+        let cuda_available = utils::is_cuda_available();
+        println!(
+            "CUDA is {}",
+            if cuda_available {
+                "'available'"
+            } else {
+                "'not available'"
+            }
+        );
+
+        let dnn_backend = if cuda_available {
+            DnnBackend::Cuda
+        } else {
+            DnnBackend::OpenCV
+        };
+        let dnn_target = if cuda_available {
+            DnnTarget::Cuda
+        } else {
+            DnnTarget::Cpu
+        };
+        println!(
+            "Using OpenCV DNN backend with {:?}/{:?}",
+            dnn_backend, dnn_target
+        );
+
+        let format = utils::detect_model_format(weights)
+            .unwrap_or_else(|e| panic!("Can't read weights file '{}': {}", weights, e));
+        println!("Detected model format: {}", format);
+
+        let model: Box<dyn ModelTrait> = match format {
+            utils::ModelFileFormat::DarknetWeights => {
+                let cfg = network_cfg.unwrap_or_else(|| {
+                    panic!(
+                        "Darknet weights '{}' require a .cfg file. Set 'network_cfg' in config.",
+                        weights
+                    )
+                });
+                match Model::darknet(cfg, weights, net_size, dnn_backend, dnn_target) {
+                    Ok(model) => Box::new(model),
+                    Err(err) => panic!(
+                        "Can't read Darknet network '{}' / '{}' due the error: {:?}",
+                        cfg, weights, err
+                    ),
+                }
+            }
+            utils::ModelFileFormat::Onnx => {
+                match Model::opencv(weights, net_size, dnn_backend, dnn_target) {
+                    Ok(model) => Box::new(model),
+                    Err(err) => panic!(
+                        "Can't read ONNX network '{}' due the error: {:?}",
+                        weights, err
+                    ),
+                }
+            }
+            other => panic!(
+                "Unsupported model format '{}' for OpenCV DNN backend. Use .weights (Darknet) or .onnx (ONNX).",
+                other
+            ),
+        };
+        Detector::OpenCV(model)
+    }
+
+    #[cfg(all(feature = "ort-backend", not(feature = "opencv-backend")))]
+    pub fn new(weights: &str, net_size: (i32, i32), _network_cfg: Option<&str>) -> Self {
+        let cuda_available = utils::is_cuda_available();
+        println!(
+            "CUDA is {}",
+            if cuda_available {
+                "'available'"
+            } else {
+                "'not available'"
+            }
+        );
+
+        #[cfg(feature = "ort-cuda")]
+        let backend_name = if cuda_available { "CUDA" } else { "CPU" };
+        #[cfg(not(feature = "ort-cuda"))]
+        let backend_name = "CPU";
+
+        println!("Using ORT backend ({})", backend_name);
+
+        let net_size_u32 = (net_size.0 as u32, net_size.1 as u32);
+
+        #[cfg(feature = "ort-cuda")]
+        let model_result = if cuda_available {
+            Model::ort_cuda(weights, net_size_u32)
+        } else {
+            Model::ort(weights, net_size_u32)
+        };
+
+        #[cfg(not(feature = "ort-cuda"))]
+        let model_result = Model::ort(weights, net_size_u32);
+
+        match model_result {
+            Ok(model) => Detector::Ort(model),
+            Err(err) => panic!(
+                "Can't create ORT model '{}' due the error: {:?}",
+                weights, err
+            ),
+        }
+    }
+
+    #[cfg(all(
+        feature = "tensorrt-backend",
+        not(feature = "opencv-backend"),
+        not(feature = "ort-backend")
+    ))]
+    pub fn new(weights: &str, net_size: (i32, i32), _network_cfg: Option<&str>) -> Self {
+        println!("Using TensorRT backend");
+        let net_size_u32 = (net_size.0 as u32, net_size.1 as u32);
+        match Model::tensorrt(weights, net_size_u32) {
+            Ok(model) => Detector::TensorRT(model),
+            Err(err) => panic!(
+                "Can't create TensorRT model '{}' due the error: {:?}",
+                weights, err
+            ),
+        }
+    }
+
+    pub fn detect_frame(
+        &mut self,
+        frame: &RawFrame,
+        conf_threshold: f32,
+        nms_threshold: f32,
+    ) -> Result<(Vec<RectCV>, Vec<usize>, Vec<f32>), String> {
+        match self {
+            #[cfg(feature = "opencv-backend")]
+            Detector::OpenCV(model) => {
+                let mut mat = Mat::new_rows_cols_with_default(
+                    frame.rows(),
+                    frame.cols(),
+                    opencv::core::CV_8UC3,
+                    opencv::core::Scalar::all(0.0),
+                )
+                .map_err(|e| e.to_string())?;
+                mat.data_bytes_mut()
+                    .map_err(|e| e.to_string())?
+                    .copy_from_slice(&frame.data);
+                let (rects, ids, confs) = model
+                    .forward(&mat, conf_threshold, nms_threshold)
+                    .map_err(|e| e.to_string())?;
+                let bboxes = rects
+                    .iter()
+                    .map(|r| RectCV::new(r.x, r.y, r.width, r.height))
+                    .collect();
+                Ok((bboxes, ids, confs))
+            }
+
+            #[cfg(all(feature = "ort-backend", not(feature = "opencv-backend")))]
+            Detector::Ort(model) => {
+                let img = raw_frame_to_image_buffer(frame);
+                let (bboxes, ids, confs) = model
+                    .forward(&img, conf_threshold, nms_threshold)
+                    .map_err(|e| format!("{:?}", e))?;
+                let rects = bboxes
+                    .iter()
+                    .map(|b| RectCV::new(b.x, b.y, b.width, b.height))
+                    .collect();
+                Ok((rects, ids, confs))
+            }
+
+            #[cfg(all(
+                feature = "tensorrt-backend",
+                not(feature = "opencv-backend"),
+                not(feature = "ort-backend")
+            ))]
+            Detector::TensorRT(model) => {
+                let img = raw_frame_to_image_buffer(frame);
+                let (bboxes, ids, confs) = model
+                    .forward(&img, conf_threshold, nms_threshold)
+                    .map_err(|e| format!("{:?}", e))?;
+                let rects = bboxes
+                    .iter()
+                    .map(|b| RectCV::new(b.x, b.y, b.width, b.height))
+                    .collect();
+                Ok((rects, ids, confs))
+            }
+        }
+    }
+}
+
+/// RawFrame (BGR24) => ImageBuffer for ort/tensorrt backends.
+/// Clones data since frame is needed later for drawing.
+#[cfg(not(feature = "opencv-backend"))]
+fn raw_frame_to_image_buffer(frame: &RawFrame) -> od_opencv::ImageBuffer {
+    let arr = ndarray::Array3::from_shape_vec(
+        (frame.height as usize, frame.width as usize, 3),
+        frame.data.clone(),
+    )
+    .expect("RawFrame dimensions mismatch");
+    od_opencv::ImageBuffer::from_bgr(arr)
+}

--- a/src/lib/detection/mod.rs
+++ b/src/lib/detection/mod.rs
@@ -1,3 +1,5 @@
+mod detector;
 mod postprocess;
 
+pub use self::detector::Detector;
 pub use self::postprocess::*;

--- a/src/lib/utils.rs
+++ b/src/lib/utils.rs
@@ -1,4 +1,5 @@
-use std::io::Read;
+use std::fs;
+use std::io::{self, Read};
 use std::path::Path;
 use std::process::Command;
 
@@ -73,8 +74,8 @@ impl std::fmt::Display for ModelFileFormat {
 /// - ONNX: protobuf format - the string "onnx" appears in the first 4KB (from opset domain "ai.onnx")
 /// - TensorRT engine: no reliable magic bytes, detected by `.engine` / `.trt` extension
 /// - Falls back to `Unknown` if none match
-pub fn detect_model_format(path: &str) -> std::io::Result<ModelFileFormat> {
-    let mut file = std::fs::File::open(path)?;
+pub fn detect_model_format(path: &str) -> io::Result<ModelFileFormat> {
+    let mut file = fs::File::open(path)?;
     let mut header = [0u8; 4096];
     let bytes_read = file.read(&mut header)?;
     let header = &header[..bytes_read];
@@ -104,10 +105,53 @@ pub fn detect_model_format(path: &str) -> std::io::Result<ModelFileFormat> {
     Ok(ModelFileFormat::Unknown)
 }
 
+/// Parse `width` and `height` from the `[net]` section of a Darknet .cfg file.
+///
+/// Darknet .cfg files are INI-style with sections like `[net]`, `[convolutional]`, etc.
+/// The `[net]` section always comes first and contains `width=N` and `height=N`.
+pub fn parse_darknet_cfg_net_size(cfg_path: &str) -> io::Result<(i32, i32)> {
+    let content = fs::read_to_string(cfg_path)?;
+    let mut width: Option<i32> = None;
+    let mut height: Option<i32> = None;
+    let mut in_net = false;
+
+    for line in content.lines() {
+        let trimmed = line.trim();
+        if trimmed == "[net]" {
+            in_net = true;
+        } else if trimmed.starts_with('[') {
+            if in_net {
+                break;
+            }
+        } else if in_net {
+            if let Some(v) = trimmed
+                .strip_prefix("width=")
+                .or_else(|| trimmed.strip_prefix("width ="))
+            {
+                width = v.trim().parse().ok();
+            } else if let Some(v) = trimmed
+                .strip_prefix("height=")
+                .or_else(|| trimmed.strip_prefix("height ="))
+            {
+                height = v.trim().parse().ok();
+            }
+        }
+    }
+
+    match (width, height) {
+        (Some(w), Some(h)) if w > 0 && h > 0 => Ok((w, h)),
+        _ => Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "Could not find valid width/height in [net] section of '{}'",
+                cfg_path
+            ),
+        )),
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use std::fs;
-
     use super::*;
 
     #[test]
@@ -164,6 +208,48 @@ mod tests {
         let fmt = detect_model_format(path).unwrap();
         assert_eq!(fmt, ModelFileFormat::Unknown);
         fs::remove_file(path).unwrap();
+    }
+
+    #[test]
+    fn parse_cfg_net_size_basic() {
+        let path = "/tmp/test_parse_cfg.cfg";
+        fs::write(path, "[net]\nbatch=1\nwidth=416\nheight=256\nchannels=3\n\n[convolutional]\n").unwrap();
+        let (w, h) = parse_darknet_cfg_net_size(path).unwrap();
+        assert_eq!((w, h), (416, 256));
+        fs::remove_file(path).unwrap();
+    }
+
+    #[test]
+    fn parse_cfg_net_size_spaces_around_eq() {
+        let path = "/tmp/test_parse_cfg_spaces.cfg";
+        fs::write(path, "[net]\nwidth = 608\nheight = 608\n").unwrap();
+        let (w, h) = parse_darknet_cfg_net_size(path).unwrap();
+        assert_eq!((w, h), (608, 608));
+        fs::remove_file(path).unwrap();
+    }
+
+    #[test]
+    fn parse_cfg_net_size_no_net_section() {
+        let path = "/tmp/test_parse_cfg_no_net.cfg";
+        fs::write(path, "[convolutional]\nfilters=32\n").unwrap();
+        let result = parse_darknet_cfg_net_size(path);
+        assert!(result.is_err());
+        fs::remove_file(path).unwrap();
+    }
+
+    #[test]
+    fn parse_cfg_net_size_nonexistent_file() {
+        let result = parse_darknet_cfg_net_size("/tmp/nonexistent_cfg_12345.cfg");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn parse_cfg_net_size_real_file() {
+        // Test against actual project .cfg files
+        if Path::new("./data/yolov4-tiny.cfg").exists() {
+            let (w, h) = parse_darknet_cfg_net_size("./data/yolov4-tiny.cfg").unwrap();
+            assert_eq!((w, h), (416, 416));
+        }
     }
 
     #[test]

--- a/src/lib/utils.rs
+++ b/src/lib/utils.rs
@@ -213,7 +213,11 @@ mod tests {
     #[test]
     fn parse_cfg_net_size_basic() {
         let path = "/tmp/test_parse_cfg.cfg";
-        fs::write(path, "[net]\nbatch=1\nwidth=416\nheight=256\nchannels=3\n\n[convolutional]\n").unwrap();
+        fs::write(
+            path,
+            "[net]\nbatch=1\nwidth=416\nheight=256\nchannels=3\n\n[convolutional]\n",
+        )
+        .unwrap();
         let (w, h) = parse_darknet_cfg_net_size(path).unwrap();
         assert_eq!((w, h), (416, 256));
         fs::remove_file(path).unwrap();

--- a/src/lib/utils.rs
+++ b/src/lib/utils.rs
@@ -1,3 +1,4 @@
+use std::io::Read;
 use std::path::Path;
 use std::process::Command;
 
@@ -41,13 +42,139 @@ pub fn is_cuda_available() -> bool {
     Path::new("/dev/nvidia0").exists()
 }
 
+/// Detected model file format.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum ModelFileFormat {
+    /// ONNX format (protobuf, contains "onnx" in header)
+    Onnx,
+    /// Darknet weights (classic YOLOv3/v4/v7 .weights format)
+    DarknetWeights,
+    /// TensorRT serialized engine
+    TensorRtEngine,
+    /// Unknown format
+    Unknown,
+}
+
+impl std::fmt::Display for ModelFileFormat {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ModelFileFormat::Onnx => write!(f, "ONNX"),
+            ModelFileFormat::DarknetWeights => write!(f, "Darknet weights"),
+            ModelFileFormat::TensorRtEngine => write!(f, "TensorRT engine"),
+            ModelFileFormat::Unknown => write!(f, "Unknown"),
+        }
+    }
+}
+
+/// Detect the model file format by examining file contents.
+///
+/// Detection logic:
+/// - ONNX: protobuf format - the string "onnx" appears in the first 4KB (from opset domain "ai.onnx")
+/// - Darknet weights: header is 3+ little-endian i32 values; major version = 0, minor = 1 or 2
+/// - TensorRT engine: no reliable magic bytes, detected by `.engine` / `.trt` extension
+/// - Falls back to `Unknown` if none match
+pub fn detect_model_format(path: &str) -> std::io::Result<ModelFileFormat> {
+    let mut file = std::fs::File::open(path)?;
+    let mut header = [0u8; 4096];
+    let bytes_read = file.read(&mut header)?;
+    let header = &header[..bytes_read];
+
+    // ONNX: protobuf contains "onnx" (from opset domain "ai.onnx")
+    if bytes_read >= 4 && header.windows(4).any(|w| w == b"onnx") {
+        return Ok(ModelFileFormat::Onnx);
+    }
+
+    // Darknet weights: [major: i32 LE, minor: i32 LE, revision: i32 LE, ...]
+    // major = 0, minor = 1 or 2
+    if bytes_read >= 12 {
+        let major = i32::from_le_bytes([header[0], header[1], header[2], header[3]]);
+        let minor = i32::from_le_bytes([header[4], header[5], header[6], header[7]]);
+        if major == 0 && (minor == 1 || minor == 2) {
+            return Ok(ModelFileFormat::DarknetWeights);
+        }
+    }
+
+    // TensorRT engine: extension-based (no reliable magic bytes)
+    if path.ends_with(".engine") || path.ends_with(".trt") {
+        return Ok(ModelFileFormat::TensorRtEngine);
+    }
+
+    Ok(ModelFileFormat::Unknown)
+}
+
 #[cfg(test)]
 mod tests {
+    use std::fs;
+
     use super::*;
 
     #[test]
     fn cuda_check_does_not_panic() {
         // Just verify the function runs without panicking on any system
         let _ = is_cuda_available();
+    }
+
+    #[test]
+    fn detect_format_nonexistent_file() {
+        let result = detect_model_format("/tmp/nonexistent_model_file_12345.bin");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn detect_format_onnx() {
+        let path = "/tmp/test_detect_format.onnx";
+        let mut data = vec![0u8; 64];
+        data[10..17].copy_from_slice(b"ai.onnx");
+        fs::write(path, &data).unwrap();
+        let fmt = detect_model_format(path).unwrap();
+        assert_eq!(fmt, ModelFileFormat::Onnx);
+        fs::remove_file(path).unwrap();
+    }
+
+    #[test]
+    fn detect_format_darknet() {
+        let path = "/tmp/test_detect_format.weights";
+        let mut data = vec![0u8; 64];
+        data[0..4].copy_from_slice(&0i32.to_le_bytes()); // major
+        data[4..8].copy_from_slice(&2i32.to_le_bytes()); // minor
+        data[8..12].copy_from_slice(&0i32.to_le_bytes()); // revision
+        fs::write(path, &data).unwrap();
+        let fmt = detect_model_format(path).unwrap();
+        assert_eq!(fmt, ModelFileFormat::DarknetWeights);
+        fs::remove_file(path).unwrap();
+    }
+
+    #[test]
+    fn detect_format_tensorrt_by_extension() {
+        let path = "/tmp/test_detect_format.engine";
+        let data = vec![0xFFu8; 64];
+        fs::write(path, &data).unwrap();
+        let fmt = detect_model_format(path).unwrap();
+        assert_eq!(fmt, ModelFileFormat::TensorRtEngine);
+        fs::remove_file(path).unwrap();
+    }
+
+    #[test]
+    fn detect_format_unknown() {
+        let path = "/tmp/test_detect_format.bin";
+        let data = vec![0xFFu8; 64];
+        fs::write(path, &data).unwrap();
+        let fmt = detect_model_format(path).unwrap();
+        assert_eq!(fmt, ModelFileFormat::Unknown);
+        fs::remove_file(path).unwrap();
+    }
+
+    #[test]
+    fn model_file_format_display() {
+        assert_eq!(format!("{}", ModelFileFormat::Onnx), "ONNX");
+        assert_eq!(
+            format!("{}", ModelFileFormat::DarknetWeights),
+            "Darknet weights"
+        );
+        assert_eq!(
+            format!("{}", ModelFileFormat::TensorRtEngine),
+            "TensorRT engine"
+        );
+        assert_eq!(format!("{}", ModelFileFormat::Unknown), "Unknown");
     }
 }

--- a/src/lib/utils.rs
+++ b/src/lib/utils.rs
@@ -68,9 +68,9 @@ impl std::fmt::Display for ModelFileFormat {
 
 /// Detect the model file format by examining file contents.
 ///
-/// Detection logic:
-/// - ONNX: protobuf format - the string "onnx" appears in the first 4KB (from opset domain "ai.onnx")
+/// Detection logic (order matters - most specific first):
 /// - Darknet weights: header is 3+ little-endian i32 values; major version = 0, minor = 1 or 2
+/// - ONNX: protobuf format - the string "onnx" appears in the first 4KB (from opset domain "ai.onnx")
 /// - TensorRT engine: no reliable magic bytes, detected by `.engine` / `.trt` extension
 /// - Falls back to `Unknown` if none match
 pub fn detect_model_format(path: &str) -> std::io::Result<ModelFileFormat> {
@@ -79,19 +79,21 @@ pub fn detect_model_format(path: &str) -> std::io::Result<ModelFileFormat> {
     let bytes_read = file.read(&mut header)?;
     let header = &header[..bytes_read];
 
-    // ONNX: protobuf contains "onnx" (from opset domain "ai.onnx")
-    if bytes_read >= 4 && header.windows(4).any(|w| w == b"onnx") {
-        return Ok(ModelFileFormat::Onnx);
-    }
-
     // Darknet weights: [major: i32 LE, minor: i32 LE, revision: i32 LE, ...]
     // major = 0, minor = 1 or 2
+    // Check first: Darknet header is specific, while ONNX substring search can false-positive
+    // on random float weights that happen to contain bytes "onnx"
     if bytes_read >= 12 {
         let major = i32::from_le_bytes([header[0], header[1], header[2], header[3]]);
         let minor = i32::from_le_bytes([header[4], header[5], header[6], header[7]]);
         if major == 0 && (minor == 1 || minor == 2) {
             return Ok(ModelFileFormat::DarknetWeights);
         }
+    }
+
+    // ONNX: protobuf contains "onnx" (from opset domain "ai.onnx")
+    if bytes_read >= 4 && header.windows(4).any(|w| w == b"onnx") {
+        return Ok(ModelFileFormat::Onnx);
     }
 
     // TensorRT engine: extension-based (no reliable magic bytes)

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,23 +1,24 @@
 use chrono::Utc;
-use opencv::{core::Mat, prelude::MatTraitManual};
 
 use lib::cv::Rect as RectCV;
 
-// Conditional imports based on backend feature
+// OpenCV DNN backend: needs Mat for inference + ModelTrait compat layer
 #[cfg(feature = "opencv-backend")]
-use od_opencv::{DnnBackend, DnnTarget, Model, model::ModelTrait, model_format::ModelFormat};
+use od_opencv::{DnnBackend, DnnTarget, Model, model::ModelTrait};
+#[cfg(feature = "opencv-backend")]
+use opencv::{core::Mat, prelude::MatTraitManual};
 
-// ORT backend uses ModelTrait from opencv_compat (does not depend on opencv/dnn)
+// ORT backend (without opencv): native od_opencv types
 #[cfg(all(feature = "ort-backend", not(feature = "opencv-backend")))]
-use od_opencv::{Model, ModelTrait};
+use od_opencv::{Model, ModelUltralyticsOrt};
 
-// TensorRT backend uses ModelTrait from opencv_compat (does not depend on opencv/dnn)
+// TensorRT backend (without opencv): native od_opencv types
 #[cfg(all(
     feature = "tensorrt-backend",
     not(feature = "opencv-backend"),
     not(feature = "ort-backend")
 ))]
-use od_opencv::{Model, ModelTrait};
+use od_opencv::{Model, ModelUltralyticsRt};
 
 use mot_rs::utils::Rect;
 use uuid::Uuid;
@@ -33,8 +34,8 @@ use lib::detection::process_yolo_detections;
 use lib::draw;
 use lib::perf_stats::{PerfStats, Timer};
 use lib::tracker::{SpatialInfo, TrackerTrait, new_tracker_from_type};
-use lib::zones::Zone;
 use lib::utils;
+use lib::zones::Zone;
 
 mod settings;
 use settings::AppSettings;
@@ -80,6 +81,7 @@ impl fmt::Display for AppVideoError {
 #[derive(Debug)]
 enum AppError {
     VideoError(AppVideoError),
+    #[cfg(feature = "opencv-backend")]
     OpenCVError(opencv::Error),
     CaptureError(video_capture::CaptureError),
 }
@@ -88,6 +90,7 @@ impl fmt::Display for AppError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             AppError::VideoError(e) => write!(f, "{}", e),
+            #[cfg(feature = "opencv-backend")]
             AppError::OpenCVError(e) => write!(f, "{}", e),
             AppError::CaptureError(e) => write!(f, "{}", e),
         }
@@ -100,6 +103,7 @@ impl From<AppVideoError> for AppError {
     }
 }
 
+#[cfg(feature = "opencv-backend")]
 impl From<opencv::Error> for AppError {
     fn from(e: opencv::Error) -> Self {
         AppError::OpenCVError(e)
@@ -112,14 +116,100 @@ impl From<video_capture::CaptureError> for AppError {
     }
 }
 
+// Backend-specific detector enum (like face_slop's PersonDetector pattern)
+enum Detector {
+    #[cfg(feature = "opencv-backend")]
+    OpenCV(Box<dyn ModelTrait>),
+
+    #[cfg(all(feature = "ort-backend", not(feature = "opencv-backend")))]
+    Ort(ModelUltralyticsOrt),
+
+    #[cfg(all(
+        feature = "tensorrt-backend",
+        not(feature = "opencv-backend"),
+        not(feature = "ort-backend")
+    ))]
+    TensorRT(ModelUltralyticsRt),
+}
+
+impl Detector {
+    fn detect_frame(
+        &mut self,
+        frame: &lib::cv::RawFrame,
+        conf_threshold: f32,
+        nms_threshold: f32,
+    ) -> Result<(Vec<RectCV>, Vec<usize>, Vec<f32>), String> {
+        match self {
+            #[cfg(feature = "opencv-backend")]
+            Detector::OpenCV(model) => {
+                let mut mat = Mat::new_rows_cols_with_default(
+                    frame.rows(),
+                    frame.cols(),
+                    opencv::core::CV_8UC3,
+                    opencv::core::Scalar::all(0.0),
+                )
+                .map_err(|e| e.to_string())?;
+                mat.data_bytes_mut()
+                    .map_err(|e| e.to_string())?
+                    .copy_from_slice(&frame.data);
+                let (rects, ids, confs) = model
+                    .forward(&mat, conf_threshold, nms_threshold)
+                    .map_err(|e| e.to_string())?;
+                let bboxes = rects
+                    .iter()
+                    .map(|r| RectCV::new(r.x, r.y, r.width, r.height))
+                    .collect();
+                Ok((bboxes, ids, confs))
+            }
+
+            #[cfg(all(feature = "ort-backend", not(feature = "opencv-backend")))]
+            Detector::Ort(model) => {
+                let img = raw_frame_to_image_buffer(frame);
+                let (bboxes, ids, confs) = model
+                    .forward(&img, conf_threshold, nms_threshold)
+                    .map_err(|e| format!("{:?}", e))?;
+                let rects = bboxes
+                    .iter()
+                    .map(|b| RectCV::new(b.x, b.y, b.width, b.height))
+                    .collect();
+                Ok((rects, ids, confs))
+            }
+
+            #[cfg(all(
+                feature = "tensorrt-backend",
+                not(feature = "opencv-backend"),
+                not(feature = "ort-backend")
+            ))]
+            Detector::TensorRT(model) => {
+                let img = raw_frame_to_image_buffer(frame);
+                let (bboxes, ids, confs) = model
+                    .forward(&img, conf_threshold, nms_threshold)
+                    .map_err(|e| format!("{:?}", e))?;
+                let rects = bboxes
+                    .iter()
+                    .map(|b| RectCV::new(b.x, b.y, b.width, b.height))
+                    .collect();
+                Ok((rects, ids, confs))
+            }
+        }
+    }
+}
+
+/// RawFrame (BGR24) => ImageBuffer for ort/tensorrt backends.
+/// Clones data since frame is needed later for drawing.
+#[cfg(not(feature = "opencv-backend"))]
+fn raw_frame_to_image_buffer(frame: &lib::cv::RawFrame) -> od_opencv::ImageBuffer {
+    let arr = ndarray::Array3::from_shape_vec(
+        (frame.height as usize, frame.width as usize, 3),
+        frame.data.clone(),
+    )
+    .expect("RawFrame dimensions mismatch");
+    od_opencv::ImageBuffer::from_bgr(arr)
+}
+
 // OpenCV DNN backend (compile-time)
 #[cfg(feature = "opencv-backend")]
-fn prepare_neural_net(
-    mf: ModelFormat,
-    weights: &str,
-    configuration: Option<String>,
-    net_size: (i32, i32),
-) -> Result<Box<dyn ModelTrait>, AppError> {
+fn prepare_neural_net(weights: &str, net_size: (i32, i32)) -> Result<Detector, AppError> {
     let cuda_available = utils::is_cuda_available();
     println!(
         "CUDA is {}",
@@ -145,38 +235,19 @@ fn prepare_neural_net(
         dnn_backend, dnn_target
     );
 
-    let neural_net: Box<dyn ModelTrait> = match mf {
-        ModelFormat::Darknet => {
-            let cfg = configuration
-                .as_deref()
-                .expect("Darknet format requires .cfg file");
-            match Model::darknet(cfg, weights, net_size, dnn_backend, dnn_target) {
-                Ok(model) => Box::new(model),
-                Err(err) => panic!(
-                    "Can't read Darknet network '{}' (with cfg '{}') due the error: {:?}",
-                    weights, cfg, err
-                ),
-            }
-        }
-        ModelFormat::ONNX => match Model::opencv(weights, net_size, dnn_backend, dnn_target) {
-            Ok(model) => Box::new(model),
-            Err(err) => panic!(
-                "Can't read ONNX network '{}' due the error: {:?}",
-                weights, err
-            ),
-        },
+    let model = match Model::opencv(weights, net_size, dnn_backend, dnn_target) {
+        Ok(model) => Box::new(model),
+        Err(err) => panic!(
+            "Can't read ONNX network '{}' due the error: {:?}",
+            weights, err
+        ),
     };
-    Ok(neural_net)
+    Ok(Detector::OpenCV(model))
 }
 
 // ORT backend (compile-time)
 #[cfg(all(feature = "ort-backend", not(feature = "opencv-backend")))]
-fn prepare_neural_net(
-    _mf: (), // Model format not used - ORT only supports ONNX
-    weights: &str,
-    _configuration: Option<String>,
-    net_size: (i32, i32),
-) -> Result<Box<dyn ModelTrait>, AppError> {
+fn prepare_neural_net(weights: &str, net_size: (i32, i32)) -> Result<Detector, AppError> {
     let cuda_available = utils::is_cuda_available();
     println!(
         "CUDA is {}",
@@ -194,18 +265,20 @@ fn prepare_neural_net(
 
     println!("Using ORT backend ({})", backend_name);
 
+    let net_size_u32 = (net_size.0 as u32, net_size.1 as u32);
+
     #[cfg(feature = "ort-cuda")]
     let model_result = if cuda_available {
-        Model::ort_cuda(weights, (net_size.0 as u32, net_size.1 as u32))
+        Model::ort_cuda(weights, net_size_u32)
     } else {
-        Model::ort(weights, (net_size.0 as u32, net_size.1 as u32))
+        Model::ort(weights, net_size_u32)
     };
 
     #[cfg(not(feature = "ort-cuda"))]
-    let model_result = Model::ort(weights, (net_size.0 as u32, net_size.1 as u32));
+    let model_result = Model::ort(weights, net_size_u32);
 
     match model_result {
-        Ok(model) => Ok(Box::new(model)),
+        Ok(model) => Ok(Detector::Ort(model)),
         Err(err) => panic!(
             "Can't create ORT model '{}' due the error: {:?}",
             weights, err
@@ -219,16 +292,11 @@ fn prepare_neural_net(
     not(feature = "opencv-backend"),
     not(feature = "ort-backend")
 ))]
-fn prepare_neural_net(
-    // ingore model format not used - TensorRT uses .engine files anyways
-    _mf: (),
-    weights: &str,
-    _configuration: Option<String>,
-    net_size: (i32, i32),
-) -> Result<Box<dyn ModelTrait>, AppError> {
+fn prepare_neural_net(weights: &str, net_size: (i32, i32)) -> Result<Detector, AppError> {
     println!("Using TensorRT backend");
-    match Model::tensorrt(weights, (net_size.0 as u32, net_size.1 as u32)) {
-        Ok(model) => Ok(Box::new(model)),
+    let net_size_u32 = (net_size.0 as u32, net_size.1 as u32);
+    match Model::tensorrt(weights, net_size_u32) {
+        Ok(model) => Ok(Detector::TensorRT(model)),
         Err(err) => panic!(
             "Can't create TensorRT model '{}' due the error: {:?}",
             weights, err
@@ -240,7 +308,7 @@ fn run(
     settings: &AppSettings,
     path_to_config: &str,
     tracker: &mut dyn TrackerTrait,
-    neural_net: &mut dyn ModelTrait,
+    detector: &mut Detector,
     verbose: bool,
 ) -> Result<(), AppError> {
     println!("Verbose is '{}'", verbose);
@@ -548,17 +616,9 @@ fn run(
         // Note: frame clone is deferred to only displaying
 
         /* Inference (preprocessing + forward pass + NMS) */
-        // Create Mat from RawFrame data for neural_net.forward()
-        let mut mat = Mat::new_rows_cols_with_default(
-            received.frame.rows(),
-            received.frame.cols(),
-            opencv::core::CV_8UC3,
-            opencv::core::Scalar::all(0.0),
-        )?;
-        mat.data_bytes_mut()?.copy_from_slice(&received.frame.data);
         let t_inference = Timer::start();
-        let (nms_bboxes_cv, nms_classes_ids, nms_confidences) =
-            match neural_net.forward(&mat, conf_threshold, nms_threshold) {
+        let (nms_bboxes, nms_classes_ids, nms_confidences) =
+            match detector.detect_frame(&received.frame, conf_threshold, nms_threshold) {
                 Ok((a, b, c)) => (a, b, c),
                 Err(err) => {
                     println!(
@@ -569,12 +629,6 @@ fn run(
                 }
             };
         let inference_time = t_inference.elapsed();
-
-        // Convert opencv::core::Rect to own Rect at the boundary
-        let nms_bboxes: Vec<RectCV> = nms_bboxes_cv
-            .iter()
-            .map(|r| RectCV::new(r.x, r.y, r.width, r.height))
-            .collect();
 
         /* Postprocessing: create detection blobs */
         let t_postprocess = Timer::start();
@@ -916,67 +970,14 @@ fn main() {
     );
     println!("Tracker is:\n\t{}", tracker);
 
-    // OpenCV backend: parse model format from config
-    #[cfg(feature = "opencv-backend")]
-    let mut neural_net = {
-        let model_format = match app_settings.detection.get_nn_format() {
-            Ok(mf) => mf,
-            Err(err) => {
-                println!("Can't get model format due the error: {}", err);
-                return;
-            }
-        };
-        match prepare_neural_net(
-            model_format,
-            &app_settings.detection.network_weights,
-            app_settings.detection.network_cfg.clone(),
-            (
-                app_settings.detection.net_width,
-                app_settings.detection.net_height,
-            ),
-        ) {
-            Ok(nn) => nn,
-            Err(err) => {
-                println!("Can't prepare neural network due the error: {}", err);
-                return;
-            }
-        }
-    };
-
-    // ORT backend: only ONNX supported
-    #[cfg(all(feature = "ort-backend", not(feature = "opencv-backend")))]
-    let mut neural_net = match prepare_neural_net(
-        (),
+    let mut detector = match prepare_neural_net(
         &app_settings.detection.network_weights,
-        app_settings.detection.network_cfg.clone(),
         (
             app_settings.detection.net_width,
             app_settings.detection.net_height,
         ),
     ) {
-        Ok(nn) => nn,
-        Err(err) => {
-            println!("Can't prepare neural network due the error: {}", err);
-            return;
-        }
-    };
-
-    // TensorRT backend: .engine files only
-    #[cfg(all(
-        feature = "tensorrt-backend",
-        not(feature = "opencv-backend"),
-        not(feature = "ort-backend")
-    ))]
-    let mut neural_net = match prepare_neural_net(
-        (),
-        &app_settings.detection.network_weights,
-        app_settings.detection.network_cfg.clone(),
-        (
-            app_settings.detection.net_width,
-            app_settings.detection.net_height,
-        ),
-    ) {
-        Ok(nn) => nn,
+        Ok(d) => d,
         Err(err) => {
             println!("Can't prepare neural network due the error: {}", err);
             return;
@@ -992,7 +993,7 @@ fn main() {
         &app_settings,
         path_to_config,
         &mut *tracker,
-        &mut *neural_net,
+        &mut detector,
         verbose,
     ) {
         Ok(_) => {}

--- a/src/main.rs
+++ b/src/main.rs
@@ -209,7 +209,11 @@ fn raw_frame_to_image_buffer(frame: &lib::cv::RawFrame) -> od_opencv::ImageBuffe
 
 // OpenCV DNN backend (compile-time)
 #[cfg(feature = "opencv-backend")]
-fn prepare_neural_net(weights: &str, net_size: (i32, i32)) -> Result<Detector, AppError> {
+fn prepare_neural_net(
+    weights: &str,
+    net_size: (i32, i32),
+    network_cfg: Option<&str>,
+) -> Result<Detector, AppError> {
     let cuda_available = utils::is_cuda_available();
     println!(
         "CUDA is {}",
@@ -235,11 +239,38 @@ fn prepare_neural_net(weights: &str, net_size: (i32, i32)) -> Result<Detector, A
         dnn_backend, dnn_target
     );
 
-    let model = match Model::opencv(weights, net_size, dnn_backend, dnn_target) {
-        Ok(model) => Box::new(model),
-        Err(err) => panic!(
-            "Can't read ONNX network '{}' due the error: {:?}",
-            weights, err
+    let format = utils::detect_model_format(weights)
+        .unwrap_or_else(|e| panic!("Can't read weights file '{}': {}", weights, e));
+    println!("Detected model format: {}", format);
+
+    let model: Box<dyn ModelTrait> = match format {
+        utils::ModelFileFormat::DarknetWeights => {
+            let cfg = network_cfg.unwrap_or_else(|| {
+                panic!(
+                    "Darknet weights '{}' require a .cfg file. Set 'network_cfg' in config.",
+                    weights
+                )
+            });
+            match Model::darknet(cfg, weights, net_size, dnn_backend, dnn_target) {
+                Ok(model) => Box::new(model),
+                Err(err) => panic!(
+                    "Can't read Darknet network '{}' / '{}' due the error: {:?}",
+                    cfg, weights, err
+                ),
+            }
+        }
+        utils::ModelFileFormat::Onnx => {
+            match Model::opencv(weights, net_size, dnn_backend, dnn_target) {
+                Ok(model) => Box::new(model),
+                Err(err) => panic!(
+                    "Can't read ONNX network '{}' due the error: {:?}",
+                    weights, err
+                ),
+            }
+        }
+        other => panic!(
+            "Unsupported model format '{}' for OpenCV DNN backend. Use .weights (Darknet) or .onnx (ONNX).",
+            other
         ),
     };
     Ok(Detector::OpenCV(model))
@@ -970,6 +1001,22 @@ fn main() {
     );
     println!("Tracker is:\n\t{}", tracker);
 
+    #[cfg(feature = "opencv-backend")]
+    let mut detector = match prepare_neural_net(
+        &app_settings.detection.network_weights,
+        (
+            app_settings.detection.net_width,
+            app_settings.detection.net_height,
+        ),
+        app_settings.detection.network_cfg.as_deref(),
+    ) {
+        Ok(d) => d,
+        Err(err) => {
+            println!("Can't prepare neural network due the error: {}", err);
+            return;
+        }
+    };
+    #[cfg(not(feature = "opencv-backend"))]
     let mut detector = match prepare_neural_net(
         &app_settings.detection.network_weights,
         (

--- a/src/main.rs
+++ b/src/main.rs
@@ -753,12 +753,16 @@ fn main() {
     );
     println!("Tracker is:\n\t{}", tracker);
 
+    let net_size = match (
+        app_settings.detection.net_width,
+        app_settings.detection.net_height,
+    ) {
+        (Some(w), Some(h)) => Some((w, h)),
+        _ => None,
+    };
     let mut detector = Detector::new(
         &app_settings.detection.network_weights,
-        (
-            app_settings.detection.net_width,
-            app_settings.detection.net_height,
-        ),
+        net_size,
         app_settings.detection.network_cfg.as_deref(),
     );
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,24 +2,6 @@ use chrono::Utc;
 
 use lib::cv::Rect as RectCV;
 
-// OpenCV DNN backend: needs Mat for inference + ModelTrait compat layer
-#[cfg(feature = "opencv-backend")]
-use od_opencv::{DnnBackend, DnnTarget, Model, model::ModelTrait};
-#[cfg(feature = "opencv-backend")]
-use opencv::{core::Mat, prelude::MatTraitManual};
-
-// ORT backend (without opencv): native od_opencv types
-#[cfg(all(feature = "ort-backend", not(feature = "opencv-backend")))]
-use od_opencv::{Model, ModelUltralyticsOrt};
-
-// TensorRT backend (without opencv): native od_opencv types
-#[cfg(all(
-    feature = "tensorrt-backend",
-    not(feature = "opencv-backend"),
-    not(feature = "ort-backend")
-))]
-use od_opencv::{Model, ModelUltralyticsRt};
-
 use mot_rs::utils::Rect;
 use uuid::Uuid;
 
@@ -29,12 +11,12 @@ use lib::data_storage::new_datastorage;
 use lib::dataset_collector::DatasetCollector;
 use lib::detection::DetectionBlobs::BBox;
 use lib::detection::DetectionBlobs::Simple;
+use lib::detection::Detector;
 use lib::detection::KalmanFilterType;
 use lib::detection::process_yolo_detections;
 use lib::draw;
 use lib::perf_stats::{PerfStats, Timer};
 use lib::tracker::{SpatialInfo, TrackerTrait, new_tracker_from_type};
-use lib::utils;
 use lib::zones::Zone;
 
 mod settings;
@@ -81,8 +63,6 @@ impl fmt::Display for AppVideoError {
 #[derive(Debug)]
 enum AppError {
     VideoError(AppVideoError),
-    #[cfg(feature = "opencv-backend")]
-    OpenCVError(opencv::Error),
     CaptureError(video_capture::CaptureError),
 }
 
@@ -90,8 +70,6 @@ impl fmt::Display for AppError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             AppError::VideoError(e) => write!(f, "{}", e),
-            #[cfg(feature = "opencv-backend")]
-            AppError::OpenCVError(e) => write!(f, "{}", e),
             AppError::CaptureError(e) => write!(f, "{}", e),
         }
     }
@@ -103,235 +81,9 @@ impl From<AppVideoError> for AppError {
     }
 }
 
-#[cfg(feature = "opencv-backend")]
-impl From<opencv::Error> for AppError {
-    fn from(e: opencv::Error) -> Self {
-        AppError::OpenCVError(e)
-    }
-}
-
 impl From<video_capture::CaptureError> for AppError {
     fn from(e: video_capture::CaptureError) -> Self {
         AppError::CaptureError(e)
-    }
-}
-
-// Backend-specific detector enum (like face_slop's PersonDetector pattern)
-enum Detector {
-    #[cfg(feature = "opencv-backend")]
-    OpenCV(Box<dyn ModelTrait>),
-
-    #[cfg(all(feature = "ort-backend", not(feature = "opencv-backend")))]
-    Ort(ModelUltralyticsOrt),
-
-    #[cfg(all(
-        feature = "tensorrt-backend",
-        not(feature = "opencv-backend"),
-        not(feature = "ort-backend")
-    ))]
-    TensorRT(ModelUltralyticsRt),
-}
-
-impl Detector {
-    fn detect_frame(
-        &mut self,
-        frame: &lib::cv::RawFrame,
-        conf_threshold: f32,
-        nms_threshold: f32,
-    ) -> Result<(Vec<RectCV>, Vec<usize>, Vec<f32>), String> {
-        match self {
-            #[cfg(feature = "opencv-backend")]
-            Detector::OpenCV(model) => {
-                let mut mat = Mat::new_rows_cols_with_default(
-                    frame.rows(),
-                    frame.cols(),
-                    opencv::core::CV_8UC3,
-                    opencv::core::Scalar::all(0.0),
-                )
-                .map_err(|e| e.to_string())?;
-                mat.data_bytes_mut()
-                    .map_err(|e| e.to_string())?
-                    .copy_from_slice(&frame.data);
-                let (rects, ids, confs) = model
-                    .forward(&mat, conf_threshold, nms_threshold)
-                    .map_err(|e| e.to_string())?;
-                let bboxes = rects
-                    .iter()
-                    .map(|r| RectCV::new(r.x, r.y, r.width, r.height))
-                    .collect();
-                Ok((bboxes, ids, confs))
-            }
-
-            #[cfg(all(feature = "ort-backend", not(feature = "opencv-backend")))]
-            Detector::Ort(model) => {
-                let img = raw_frame_to_image_buffer(frame);
-                let (bboxes, ids, confs) = model
-                    .forward(&img, conf_threshold, nms_threshold)
-                    .map_err(|e| format!("{:?}", e))?;
-                let rects = bboxes
-                    .iter()
-                    .map(|b| RectCV::new(b.x, b.y, b.width, b.height))
-                    .collect();
-                Ok((rects, ids, confs))
-            }
-
-            #[cfg(all(
-                feature = "tensorrt-backend",
-                not(feature = "opencv-backend"),
-                not(feature = "ort-backend")
-            ))]
-            Detector::TensorRT(model) => {
-                let img = raw_frame_to_image_buffer(frame);
-                let (bboxes, ids, confs) = model
-                    .forward(&img, conf_threshold, nms_threshold)
-                    .map_err(|e| format!("{:?}", e))?;
-                let rects = bboxes
-                    .iter()
-                    .map(|b| RectCV::new(b.x, b.y, b.width, b.height))
-                    .collect();
-                Ok((rects, ids, confs))
-            }
-        }
-    }
-}
-
-/// RawFrame (BGR24) => ImageBuffer for ort/tensorrt backends.
-/// Clones data since frame is needed later for drawing.
-#[cfg(not(feature = "opencv-backend"))]
-fn raw_frame_to_image_buffer(frame: &lib::cv::RawFrame) -> od_opencv::ImageBuffer {
-    let arr = ndarray::Array3::from_shape_vec(
-        (frame.height as usize, frame.width as usize, 3),
-        frame.data.clone(),
-    )
-    .expect("RawFrame dimensions mismatch");
-    od_opencv::ImageBuffer::from_bgr(arr)
-}
-
-// OpenCV DNN backend (compile-time)
-#[cfg(feature = "opencv-backend")]
-fn prepare_neural_net(
-    weights: &str,
-    net_size: (i32, i32),
-    network_cfg: Option<&str>,
-) -> Result<Detector, AppError> {
-    let cuda_available = utils::is_cuda_available();
-    println!(
-        "CUDA is {}",
-        if cuda_available {
-            "'available'"
-        } else {
-            "'not available'"
-        }
-    );
-
-    let dnn_backend = if cuda_available {
-        DnnBackend::Cuda
-    } else {
-        DnnBackend::OpenCV
-    };
-    let dnn_target = if cuda_available {
-        DnnTarget::Cuda
-    } else {
-        DnnTarget::Cpu
-    };
-    println!(
-        "Using OpenCV DNN backend with {:?}/{:?}",
-        dnn_backend, dnn_target
-    );
-
-    let format = utils::detect_model_format(weights)
-        .unwrap_or_else(|e| panic!("Can't read weights file '{}': {}", weights, e));
-    println!("Detected model format: {}", format);
-
-    let model: Box<dyn ModelTrait> = match format {
-        utils::ModelFileFormat::DarknetWeights => {
-            let cfg = network_cfg.unwrap_or_else(|| {
-                panic!(
-                    "Darknet weights '{}' require a .cfg file. Set 'network_cfg' in config.",
-                    weights
-                )
-            });
-            match Model::darknet(cfg, weights, net_size, dnn_backend, dnn_target) {
-                Ok(model) => Box::new(model),
-                Err(err) => panic!(
-                    "Can't read Darknet network '{}' / '{}' due the error: {:?}",
-                    cfg, weights, err
-                ),
-            }
-        }
-        utils::ModelFileFormat::Onnx => {
-            match Model::opencv(weights, net_size, dnn_backend, dnn_target) {
-                Ok(model) => Box::new(model),
-                Err(err) => panic!(
-                    "Can't read ONNX network '{}' due the error: {:?}",
-                    weights, err
-                ),
-            }
-        }
-        other => panic!(
-            "Unsupported model format '{}' for OpenCV DNN backend. Use .weights (Darknet) or .onnx (ONNX).",
-            other
-        ),
-    };
-    Ok(Detector::OpenCV(model))
-}
-
-// ORT backend (compile-time)
-#[cfg(all(feature = "ort-backend", not(feature = "opencv-backend")))]
-fn prepare_neural_net(weights: &str, net_size: (i32, i32)) -> Result<Detector, AppError> {
-    let cuda_available = utils::is_cuda_available();
-    println!(
-        "CUDA is {}",
-        if cuda_available {
-            "'available'"
-        } else {
-            "'not available'"
-        }
-    );
-
-    #[cfg(feature = "ort-cuda")]
-    let backend_name = if cuda_available { "CUDA" } else { "CPU" };
-    #[cfg(not(feature = "ort-cuda"))]
-    let backend_name = "CPU";
-
-    println!("Using ORT backend ({})", backend_name);
-
-    let net_size_u32 = (net_size.0 as u32, net_size.1 as u32);
-
-    #[cfg(feature = "ort-cuda")]
-    let model_result = if cuda_available {
-        Model::ort_cuda(weights, net_size_u32)
-    } else {
-        Model::ort(weights, net_size_u32)
-    };
-
-    #[cfg(not(feature = "ort-cuda"))]
-    let model_result = Model::ort(weights, net_size_u32);
-
-    match model_result {
-        Ok(model) => Ok(Detector::Ort(model)),
-        Err(err) => panic!(
-            "Can't create ORT model '{}' due the error: {:?}",
-            weights, err
-        ),
-    }
-}
-
-// TensorRT backend (compile-time)
-#[cfg(all(
-    feature = "tensorrt-backend",
-    not(feature = "opencv-backend"),
-    not(feature = "ort-backend")
-))]
-fn prepare_neural_net(weights: &str, net_size: (i32, i32)) -> Result<Detector, AppError> {
-    println!("Using TensorRT backend");
-    let net_size_u32 = (net_size.0 as u32, net_size.1 as u32);
-    match Model::tensorrt(weights, net_size_u32) {
-        Ok(model) => Ok(Detector::TensorRT(model)),
-        Err(err) => panic!(
-            "Can't create TensorRT model '{}' due the error: {:?}",
-            weights, err
-        ),
     }
 }
 
@@ -1001,35 +753,14 @@ fn main() {
     );
     println!("Tracker is:\n\t{}", tracker);
 
-    #[cfg(feature = "opencv-backend")]
-    let mut detector = match prepare_neural_net(
+    let mut detector = Detector::new(
         &app_settings.detection.network_weights,
         (
             app_settings.detection.net_width,
             app_settings.detection.net_height,
         ),
         app_settings.detection.network_cfg.as_deref(),
-    ) {
-        Ok(d) => d,
-        Err(err) => {
-            println!("Can't prepare neural network due the error: {}", err);
-            return;
-        }
-    };
-    #[cfg(not(feature = "opencv-backend"))]
-    let mut detector = match prepare_neural_net(
-        &app_settings.detection.network_weights,
-        (
-            app_settings.detection.net_width,
-            app_settings.detection.net_height,
-        ),
-    ) {
-        Ok(d) => d,
-        Err(err) => {
-            println!("Can't prepare neural network due the error: {}", err);
-            return;
-        }
-    };
+    );
 
     let verbose = match &app_settings.debug {
         Some(x) => x.enable,

--- a/src/settings/settings.rs
+++ b/src/settings/settings.rs
@@ -38,8 +38,8 @@ pub struct DetectionSettings {
     pub network_cfg: Option<String>,
     pub conf_threshold: f32,
     pub nms_threshold: f32,
-    pub net_width: i32,
-    pub net_height: i32,
+    pub net_width: Option<i32>,
+    pub net_height: Option<i32>,
     pub net_classes: Vec<String>,
     pub target_classes: Option<Vec<String>>,
     /// Inference backend: "ort" for ONNX Runtime, "opencv" for OpenCV DNN.

--- a/src/settings/settings.rs
+++ b/src/settings/settings.rs
@@ -7,10 +7,6 @@ use std::fmt;
 use std::str::FromStr;
 use toml;
 
-// model_format is only available with opencv-backend
-#[cfg(feature = "opencv-backend")]
-use od_opencv::model_format::{ModelFormat, ModelVersion};
-
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct AppSettings {
     pub input: InputSettings,
@@ -38,8 +34,6 @@ pub struct DebugSettings {
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct DetectionSettings {
-    pub network_ver: Option<i32>,
-    pub network_format: Option<String>,
     pub network_weights: String,
     pub network_cfg: Option<String>,
     pub conf_threshold: f32,
@@ -56,44 +50,6 @@ pub struct DetectionSettings {
     pub perf_stats_interval: u32,
 }
 
-// These methods are only available with opencv-backend
-#[cfg(feature = "opencv-backend")]
-impl DetectionSettings {
-    pub fn get_nn_format(&self) -> Result<ModelFormat, Box<dyn Error>> {
-        match self.network_format.clone() {
-            Some(mf) => match mf.to_lowercase().as_str() {
-                "darknet" => Ok(ModelFormat::Darknet),
-                "onnx" => Ok(ModelFormat::ONNX),
-                _ => {
-                    return Err(format!(
-                        "Can't prepare neural network due the unhandled format: {}",
-                        mf
-                    )
-                    .into());
-                }
-            },
-            None => Ok(ModelFormat::Darknet),
-        }
-    }
-    pub fn get_nn_version(&self) -> Result<ModelVersion, Box<dyn Error>> {
-        match self.network_ver.clone() {
-            Some(mv) => match mv {
-                3 => Ok(ModelVersion::V3),
-                4 => Ok(ModelVersion::V4),
-                7 => Ok(ModelVersion::V7),
-                8 => Ok(ModelVersion::V8),
-                _ => {
-                    return Err(format!(
-                        "Can't prepare neural network due the unhandled version: {}",
-                        mv
-                    )
-                    .into());
-                }
-            },
-            None => Ok(ModelVersion::V3),
-        }
-    }
-}
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct TrackingSettings {
     // Either "bytetrack" or "iou_naive". Default is "iou_naive"

--- a/src/video_capture/capture.rs
+++ b/src/video_capture/capture.rs
@@ -432,11 +432,11 @@ fn spawn_gstreamer(pipeline: &str, _info: &VideoCaptureInfo) -> Result<Child, Ca
             cmd.arg("!");
         }
         // Split segment into tokens, but keep caps (containing parentheses) as one arg.
-        // Example: "v4l2src device=/dev/video0" → ["v4l2src", "device=/dev/video0"]
-        // Example: "video/x-raw, format=(string)YUY2, width=(int)1280" → one arg
+        // Example: "v4l2src device=/dev/video0" => ["v4l2src", "device=/dev/video0"]
+        // Example: "video/x-raw, format=(string)YUY2, width=(int)1280" => one arg
         if segment.contains("=(") {
             // Caps filter: remove spaces after commas so gst-launch-1.0 parses it as one token.
-            // "video/x-raw, format=(string)BGR, width=(int)640" → "video/x-raw,format=(string)BGR,width=(int)640"
+            // "video/x-raw, format=(string)BGR, width=(int)640" => "video/x-raw,format=(string)BGR,width=(int)640"
             let caps = segment.replace(", ", ",");
             cmd.arg(caps);
         } else {


### PR DESCRIPTION
Finally closes #46 

OpenCV backend is still default, but could be ignored completely. As updated README.md states:
```bash
# OpenCV backend (default) - requires OpenCV installed, supports traditional and Ultralytics models
cargo build --release

# ORT backend - no OpenCV needed at all
cargo build --release --no-default-features --features ort-backend

# TensorRT backend - no OpenCV needed at all (Jetson / NVIDIA GPU)
cargo build --release --no-default-features --features tensorrt-backend

# Any backend + vendored libjpeg-turbo (no system lib needed, requires cmake)
cargo build --release --features turbojpeg-vendor
cargo build --release --no-default-features --features tensorrt-backend,turbojpeg-vendor
cargo build --release --no-default-features --features ort-backend,turbojpeg-vendor
```

In my case of JetsonNano 4gb with:
```bash
cargo build --release --no-default-features --features tensorrt-backend,turbojpeg-vendor
ldd ./target/release/rust-road-traffic
```
gives:
```
linux-vdso.so.1 (0x0000007fa231e000)
libstdc++.so.6 => /usr/lib/aarch64-linux-gnu/libstdc++.so.6 (0x0000007fa15da000)
libnvinfer.so.8 => /usr/lib/aarch64-linux-gnu/libnvinfer.so.8 (0x0000007f97661000)
libcudart.so.10.2 => /usr/local/cuda-10.2/targets/aarch64-linux/lib/libcudart.so.10.2 (0x0000007f975d9000)
libgcc_s.so.1 => /lib/aarch64-linux-gnu/libgcc_s.so.1 (0x0000007f975b5000)
libpthread.so.0 => /lib/aarch64-linux-gnu/libpthread.so.0 (0x0000007f97589000)
libm.so.6 => /lib/aarch64-linux-gnu/libm.so.6 (0x0000007f974d0000)
libdl.so.2 => /lib/aarch64-linux-gnu/libdl.so.2 (0x0000007f974bb000)
libc.so.6 => /lib/aarch64-linux-gnu/libc.so.6 (0x0000007f97362000)
/lib/ld-linux-aarch64.so.1 (0x0000007fa22f2000)
librt.so.1 => /lib/aarch64-linux-gnu/librt.so.1 (0x0000007f9734b000)
libnvdla_compiler.so => /usr/lib/aarch64-linux-gnu/tegra/libnvdla_compiler.so (0x0000007f96eb9000)
libEGL.so.1 => /usr/lib/aarch64-linux-gnu/libEGL.so.1 (0x0000007f96e98000)
libnvmedia.so => /usr/lib/aarch64-linux-gnu/tegra/libnvmedia.so (0x0000007f96e2c000)
libnvos.so => /usr/lib/aarch64-linux-gnu/tegra/libnvos.so (0x0000007f96e0e000)
libGLdispatch.so.0 => /usr/lib/aarch64-linux-gnu/libGLdispatch.so.0 (0x0000007f96ce2000)
libnvrm.so => /usr/lib/aarch64-linux-gnu/tegra/libnvrm.so (0x0000007f96cae000)
libnvrm_graphics.so => /usr/lib/aarch64-linux-gnu/tegra/libnvrm_graphics.so (0x0000007f96c8e000)
libnvdc.so => /usr/lib/aarch64-linux-gnu/tegra/libnvdc.so (0x0000007f96c71000)
libnvtvmr.so => /usr/lib/aarch64-linux-gnu/tegra/libnvtvmr.so (0x0000007f96be1000)
libnvparser.so => /usr/lib/aarch64-linux-gnu/tegra/libnvparser.so (0x0000007f96ba3000)
libnvdla_runtime.so => /usr/lib/aarch64-linux-gnu/tegra/libnvdla_runtime.so (0x0000007f96afd000)
libnvimp.so => /usr/lib/aarch64-linux-gnu/tegra/libnvimp.so (0x0000007f96ae8000)
```


Also:
- automatic detection of network width/height in case using traditional Darknet with OpenCV backend or TensorRT backend (bumped od_opencv to v0.8.2 - https://github.com/LdDl/object-detection-opencv-rust/releases/tag/v0.8.2)
- removed `network_ver` and `network_format` fields from TOML configuration since they are obsolete now