### PR TITLE
fix(tracker): real frame timestamps and Kalman dt, ByteTrack id propagation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1645,9 +1645,9 @@ dependencies = [
 
 [[package]]
 name = "kalman-rust"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b85cae44c63531cb068126fe4e12cd6f51cbb08602dfe66c4bc8c53610af1838"
+checksum = "895704e731e67bd9628fb15282f3451a33ffd5b9572b07350868aa008c6c2d21"
 dependencies = [
  "chrono",
  "nalgebra",
@@ -1821,9 +1821,9 @@ dependencies = [
 
 [[package]]
 name = "mot-rs"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da852765e16337a3b1d0c74655fba66d312d1d649fe7cc0bfbc1439aec16d029"
+checksum = "588837a2bd1a67cf2a819c7051857970154861435fdb240eec9aab7bc9bb0d2b"
 dependencies = [
  "chrono",
  "itertools 0.11.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ ctrlc = { version = "3.0", features = ["termination"] }
 redis = { version = "0.32.7" }
 tokio = { version = "1.16.1", features = ["full"] }
 futures = "0.3.1"
-mot-rs = "0.5.0"
+mot-rs = "0.5.1"
 utoipa = { version = "3", features = ["actix_extras"] }
 utoipa-rapidoc = { version = "0.1", features = ["actix-web"] }
 # Object detection with YOLO models

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,6 +37,7 @@ use std::process;
 use std::sync::mpsc;
 use std::thread;
 use std::time::Duration as STDDuration;
+use std::time::Instant;
 use std::time::SystemTime;
 
 fn get_sys_time_in_secs() -> u64 {
@@ -267,13 +268,15 @@ fn run(
         mpsc::SyncSender<ThreadedFrame>,
         mpsc::Receiver<ThreadedFrame>,
     ) = mpsc::sync_channel(0);
+    // @experimental
+    let skip_every_n_frame: u64 = 2;
+    let live_source = video_source.is_live();
     thread::spawn(move || {
-        let mut frames_counter: f32 = 0.0;
-        let mut total_seconds: f32 = 0.0;
-        let mut overall_seconds: f32 = 0.0;
+        let mut frame_idx: u64 = 0;
         let mut processed_frames: u32 = 0;
-        // @experimental
-        let skip_every_n_frame = 2;
+        // Start of the current statistics period, in frame timestamps
+        let mut period_start_ts: f64 = 0.0;
+        let clock = Instant::now();
         loop {
             let read_frame = match video_source.read_frame() {
                 Ok(Some(frame)) => frame,
@@ -287,22 +290,24 @@ fn run(
                 }
             };
 
-            frames_counter += 1.0;
-            let second_fraction = total_seconds + (frames_counter / fps);
-            if frames_counter >= fps {
-                total_seconds += 1.0;
-                overall_seconds += 1.0;
-                frames_counter = 0.0;
-            }
-            if frames_counter as i32 % skip_every_n_frame != 0 {
+            // Live sources are paced by the source itself, so the wall clock is the
+            // only thing that reflects frames dropped upstream. A file is decoded as
+            // fast as the detector drains the pipe, so only the frame index tells
+            // media time there
+            let timestamp: f64 = if live_source {
+                clock.elapsed().as_secs_f64()
+            } else {
+                frame_idx as f64 / fps as f64
+            };
+            frame_idx += 1;
+            if frame_idx % skip_every_n_frame != 0 {
                 continue;
             }
 
             /* Send frame and capture info */
             let frame = ThreadedFrame {
                 frame: read_frame,
-                overall_seconds: overall_seconds,
-                current_second: second_fraction,
+                timestamp,
             };
 
             match tx_capture.send(frame) {
@@ -322,12 +327,12 @@ fn run(
                 );
             }
 
-            if total_seconds >= next_reset {
+            if timestamp - period_start_ts >= next_reset as f64 {
                 println!(
                     "Reset timer due analytics. Current local time is: {}",
-                    second_fraction
+                    timestamp
                 );
-                total_seconds = 0.0;
+                period_start_ts = timestamp;
                 let mut ds_writer = ds_worker.write().expect("Bad DS");
                 if ds_writer.period_end == ds_writer.period_start {
                     // First iteration
@@ -371,7 +376,11 @@ fn run(
 
     let ds_tracker = data_storage.clone();
 
-    let tracker_dt = 1.0 / fps;
+    // Nominal interval between the frames the tracker actually sees: every N-th
+    // frame is processed, so the effective rate is fps / N, not fps
+    let nominal_dt: f64 = skip_every_n_frame as f64 / fps as f64;
+    // Timestamp of the last frame that reached the tracker
+    let mut prev_tracked_ts: Option<f64> = None;
 
     /* Performance stats (optional) */
     let perf_stats_interval = settings.detection.perf_stats_interval;
@@ -398,7 +407,7 @@ fn run(
         if report_mode && first_frame.is_none() {
             first_frame = Some(received.frame.clone());
         }
-        // println!("Received frame from capture thread: {}", received.current_second);
+        // println!("Received frame from capture thread: {}", received.timestamp);
         // Note: frame clone is deferred to only displaying
 
         /* Inference (preprocessing + forward pass + NMS) */
@@ -417,6 +426,17 @@ fn run(
         let inference_time = t_inference.elapsed();
 
         /* Postprocessing: create detection blobs */
+        // The Kalman filters are rebuilt for the real interval since the previous
+        // tracked frame rather than 1/fps: a slow detector, a decoder stall or
+        // frames dropped by the source all stretch it, and a filter built for the
+        // nominal step then predicts a whole stride short and loses the match.
+        // Clamped so that a long stall can't make it extrapolate for seconds
+        let dt: f64 = match prev_tracked_ts {
+            Some(prev) if received.timestamp > prev => {
+                (received.timestamp - prev).clamp(nominal_dt * 0.25, nominal_dt * 10.0)
+            }
+            _ => nominal_dt,
+        };
         let t_postprocess = Timer::start();
         let mut tmp_detections = process_yolo_detections(
             &nms_bboxes,
@@ -427,14 +447,14 @@ fn run(
             max_points_in_track,
             &net_classes,
             &target_classes,
-            tracker_dt,
+            dt as f32,
             kalman_filter,
         );
         let postprocess_time = t_postprocess.elapsed();
 
         /* Tracking: match detections to existing tracks */
         let t_tracking = Timer::start();
-        let relative_time = received.overall_seconds;
+        let relative_time = received.timestamp as f32;
         match tracker.match_objects(&mut tmp_detections, relative_time) {
             Ok(_) => {}
             Err(err) => {
@@ -442,6 +462,7 @@ fn run(
                 continue;
             }
         };
+        prev_tracked_ts = Some(received.timestamp);
         let tracking_time = t_tracking.elapsed();
 
         /* Record performance stats */

--- a/src/video_capture/capture.rs
+++ b/src/video_capture/capture.rs
@@ -57,6 +57,7 @@ pub struct VideoSource {
     height: u32,
     fps: f32,
     total_frames: f32,
+    live: bool,
     frame_size: usize,
     buf: Vec<u8>,
 }
@@ -79,6 +80,7 @@ impl VideoSource {
 
         let child = spawn_subprocess(video_src, &kind, &info)?;
         let frame_size = info.width as usize * info.height as usize * 3;
+        let live = is_live_source(video_src, &kind);
 
         Ok(Self {
             child,
@@ -86,6 +88,7 @@ impl VideoSource {
             height: info.height,
             fps: info.fps,
             total_frames: info.total_frames,
+            live,
             frame_size,
             buf: vec![0u8; frame_size],
         })
@@ -129,6 +132,14 @@ impl VideoSource {
     pub fn total_frames(&self) -> f32 {
         self.total_frames
     }
+
+    /// Whether frames arrive at the source's own pace (camera, RTSP, live GStreamer
+    /// pipeline) rather than as fast as the consumer drains the pipe (file).
+    /// Decides which clock frame timestamps come from: wall clock for live sources,
+    /// frame index / fps for files.
+    pub fn is_live(&self) -> bool {
+        self.live
+    }
 }
 
 impl Drop for VideoSource {
@@ -138,9 +149,6 @@ impl Drop for VideoSource {
     }
 }
 
-// ---------------------------------------------------------------------------
-// Internal helpers
-// ---------------------------------------------------------------------------
 
 fn detect_source_kind(src: &str) -> SourceKind {
     if src.starts_with("rtsp://") || src.starts_with("rtsps://") {
@@ -153,6 +161,21 @@ fn detect_source_kind(src: &str) -> SourceKind {
         SourceKind::Camera(src.to_string())
     } else {
         SourceKind::File
+    }
+}
+
+/// Live sources deliver frames in real time, so dropped frames show up as a longer
+/// wall-clock gap. A file is decoded by ffmpeg without `-re`, i.e. as fast as the
+/// detector reads it, so wall clock says nothing about media time there.
+/// A GStreamer pipeline is treated as live unless it reads from a file source.
+fn is_live_source(src: &str, kind: &SourceKind) -> bool {
+    match kind {
+        SourceKind::File => false,
+        SourceKind::GStreamer => {
+            let first_token = src.split_whitespace().next().unwrap_or("");
+            first_token != "filesrc" && first_token != "multifilesrc"
+        }
+        SourceKind::Rtsp | SourceKind::Camera(_) => true,
     }
 }
 
@@ -665,6 +688,28 @@ mod tests {
         assert!(matches!(
             detect_source_kind("./video!test.mp4"),
             SourceKind::File
+        ));
+    }
+
+    #[test]
+    fn live_source_detection() {
+        assert!(!is_live_source("/tmp/video.mp4", &SourceKind::File));
+        assert!(is_live_source("rtsp://cam/stream", &SourceKind::Rtsp));
+        assert!(is_live_source(
+            "/dev/video0",
+            &SourceKind::Camera("/dev/video0".into())
+        ));
+        assert!(is_live_source(
+            "v4l2src device=/dev/video0 ! videoconvert ! appsink",
+            &SourceKind::GStreamer
+        ));
+        assert!(!is_live_source(
+            "filesrc location=/tmp/v.mp4 ! decodebin ! videoconvert ! appsink",
+            &SourceKind::GStreamer
+        ));
+        assert!(!is_live_source(
+            "multifilesrc location=/tmp/%04d.png ! decodebin ! appsink",
+            &SourceKind::GStreamer
         ));
     }
 

--- a/src/video_capture/frame.rs
+++ b/src/video_capture/frame.rs
@@ -2,6 +2,8 @@ use crate::lib::cv::RawFrame;
 
 pub struct ThreadedFrame {
     pub frame: RawFrame,
-    pub overall_seconds: f32,
-    pub current_second: f32,
+    /// Seconds since capture start. Media time (frame index / fps) for files,
+    /// wall clock for live sources. f64 so that the interval between two frames
+    /// stays exact after days of uptime; f32 loses ~10 ms per step past ~1e5 s.
+    pub timestamp: f64,
 }


### PR DESCRIPTION
Bumped `mot-rs` which is fix how the tracking pipeline measures time. Three related problems:
1. Kalman `dt` was hardcoded to `1/fps`.

The capture thread processes every 2nd frame (`skip_every_n_frame = 2`), so the filter was always built for a step half the real one - even on a perfectly regular file. On live sources the real step also drifts with decoder stalls, dropped frames and detector load. A filter built for the wrong step predicts short, the IoU with the detection drops below threshold and the track breaks for purely arithmetic reasons.

2. ByteTrack never wrote track ids back into detections (fixed upstream in [mot-rs v0.5.1](https://github.com/LdDl/mot-rs/releases/tag/v0.5.1)).

This project keys `objects_extra` (track times, class, `SpatialInfo`) by `detection.get_id()`, so with `type = "bytetrack"` every tracked object looked new on every frame: track history never grew past one point and speed was always `-1`. `iou_naive` was unaffected.

3. Time fed to the tracker and speed estimation was integer seconds.

`ThreadedFrame.overall_seconds` incremented once per `fps` frames and was the value used as `relative_time`; the fractional `current_second` existed but was unused. `SpatialInfo::update_avg` therefore divided distance by a `time_diff` of 0, 1, 2… - vehicles crossing a zone in under 1 s never got a speed, and 1.4 s became 1 or 2.


So changes are:
- `ThreadedFrame` now carries a single `timestamp: f64` (seconds since capture start). Media time (`frame_idx / fps`) for files - ffmpeg runs without `-re` so wall clock is meaningless there; wall clock (`Instant`) for live sources, where it is the only thing that reflects frames dropped upstream. `f64` so the per-frame interval stays exact after days of uptime.
- `VideoSource::is_live()` - RTSP, V4L2 and GStreamer pipelines (unless they start with `filesrc`/`multifilesrc`) are live; files are not.
- Detection loop computes `dt` as the interval since the last frame that actually reached the tracker, clamped to `[0.25, 10] * nominal_dt`, where `nominal_dt = skip_every_n_frame / fps`. Passed into `process_yolo_detections`  `BlobBBox::new_with_dt` / `SimpleBlob::new_with_center_dt`; mot-rs 0.5.1 then rebuilds `A`/`B`/`Q` of existing tracks from it (`x`, `P`, `H`, `R` untouched).
- `relative_time` and the statistics reset timer use the new timestamp.
- Frame skipping uses a monotonic frame index; the old `frames_counter` reset every `fps` frames and produced an uneven 3-frame gap once per second at 25 fps.