### PR TITLE
Time-based track expiration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1821,9 +1821,9 @@ dependencies = [
 
 [[package]]
 name = "mot-rs"
-version = "0.5.1"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "588837a2bd1a67cf2a819c7051857970154861435fdb240eec9aab7bc9bb0d2b"
+checksum = "d7e9e21962f5b26929796ddab31d1e3f336d253f17e0aee6ca01a9fc821f3455"
 dependencies = [
  "chrono",
  "itertools 0.11.0",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ ctrlc = { version = "3.0", features = ["termination"] }
 redis = { version = "0.32.7" }
 tokio = { version = "1.16.1", features = ["full"] }
 futures = "0.3.1"
-mot-rs = "0.5.1"
+mot-rs = "0.6.0"
 utoipa = { version = "3", features = ["actix_extras"] }
 utoipa-rapidoc = { version = "0.1", features = ["actix-web"] }
 # Object detection with YOLO models

--- a/README.md
+++ b/README.md
@@ -256,16 +256,21 @@ Locally you can access Swagger UI documentation via http://localhost:42001/api/d
         # Kalman filter type: "centroid" or "bbox"
         # Default is "centroid"
         kalman_filter = "centroid"
-        # Maximum number of frames to keep tracking an object without new detections. Default is 60.
-        # Increase this value (e.g., 90-120) for better OD matrix results when objects need to traverse between distant zones.
-        max_no_match = 60
+        # How long (seconds) to keep a track alive without new detections. Default is 2.0.
+        # Counted in real time, so it means the same on a file, a live stream, with frame skipping
+        # and with a throttled detector. Increase (e.g. 3-4) for better OD matrix results when
+        # objects need to traverse between distant zones.
+        max_lost_seconds = 2.0
+        # Legacy frame-count limit, only used when `max_lost_seconds` is not set.
+        # max_no_match = 60
         # IoU threshold for matching detections to existing tracks. Default is 0.3.
         # Lower values (0.2-0.25) make matching stricter, higher values (0.4-0.5) make it more permissive.
         iou_threshold = 0.3
     ```
 
     **Configurable parameters:**
-    - `max_no_match` (default: 60): Maximum consecutive frames without detection before dropping a track. Increase for better OD matrix tracking across distant zones.
+    - `max_lost_seconds` (default: 2.0): How long a track survives without detections, in seconds of real time. Increase for better OD matrix tracking across distant zones.
+    - `max_no_match`: The same limit as a frame count; only used when `max_lost_seconds` is not set. A frame count changes meaning with the effective frame rate (frame skipping, a slow detector, a stalled stream), so prefer seconds.
     - `iou_threshold` (default: 0.3): IoU threshold for matching detections to tracks. Lower = stricter matching.
 
     **Fixed parameters for ByteTrack:**

--- a/data/conf.toml
+++ b/data/conf.toml
@@ -7,6 +7,11 @@
     # video_src = "0"
     # Gstreamer:
     # video_src = "v4l2src device=/dev/video0 ! video/x-raw, format=(string)YUY2, width=(int)2560, height=(int)960, framerate=(fraction)30/1 ! videoconvert ! video/x-raw, format=(string)BGR ! appsink"
+    # Run detection and tracking on every N-th decoded frame. Default is 2.
+    # The tracker is told the real interval between the frames it sees (media time for a file,
+    # wall clock for a live source), so this only trades accuracy for CPU. On a live source a
+    # detector that falls behind additionally skips whatever frames it did not get to.
+    process_every_nth_frame = 2
 
 [debug]
     enable = true
@@ -36,6 +41,11 @@
     # Kalman filter type: "centroid" (x/y/vx/vy) or "bbox" (full bbox tracking: x/y/w/h/vx/vy/vw/vh)
     # Default is "centroid". Use "bbox" for better tracking when object size/aspect ratio changes significantly.
     kalman_filter = "bbox"
+    # How long (seconds) to keep a track alive without new detections. Default is 2.0.
+    # Counted in real time, so it means the same thing on a file, a live stream, with frame
+    # skipping and with a throttled detector. Increase for OD matrix tracking between distant zones.
+    # The legacy `max_no_match` (frames) is only used when this is not set.
+    max_lost_seconds = 2.0
 
 [equipment_info]
     # Just field for future identification of application. Could be any string.

--- a/data/conf2.toml
+++ b/data/conf2.toml
@@ -7,6 +7,11 @@
     # video_src = "0"
     # Gstreamer:
     # video_src = "v4l2src device=/dev/video0 ! video/x-raw, format=(string)YUY2, width=(int)2560, height=(int)960, framerate=(fraction)30/1 ! videoconvert ! video/x-raw, format=(string)BGR ! appsink"
+    # Run detection and tracking on every N-th decoded frame. Default is 2.
+    # The tracker is told the real interval between the frames it sees (media time for a file,
+    # wall clock for a live source), so this only trades accuracy for CPU. On a live source a
+    # detector that falls behind additionally skips whatever frames it did not get to.
+    process_every_nth_frame = 2
 
 [debug]
     enable = true
@@ -31,6 +36,11 @@
     type = "iou_naive"
     # Adjust number of points for each object in its track
     max_points_in_track = 100
+    # How long (seconds) to keep a track alive without new detections. Default is 2.0.
+    # Counted in real time, so it means the same thing on a file, a live stream, with frame
+    # skipping and with a throttled detector. Increase for OD matrix tracking between distant zones.
+    # The legacy `max_no_match` (frames) is only used when this is not set.
+    max_lost_seconds = 2.0
 
 [equipment_info]
     # Just field for future identification of application. Could be any string.

--- a/src/lib/perf_stats.rs
+++ b/src/lib/perf_stats.rs
@@ -11,6 +11,8 @@ pub struct PerfStats {
     inference_total: Duration,
     postprocess_total: Duration,
     tracking_total: Duration,
+    /// Frames the capture thread replaced before the detector took them (live sources only)
+    dropped_total: u64,
 }
 
 impl PerfStats {
@@ -21,6 +23,7 @@ impl PerfStats {
             inference_total: Duration::ZERO,
             postprocess_total: Duration::ZERO,
             tracking_total: Duration::ZERO,
+            dropped_total: 0,
         }
     }
 
@@ -30,10 +33,18 @@ impl PerfStats {
     /// * `inference` - Time for neural_net.forward() (preprocessing + inference + NMS)
     /// * `postprocess` - Time for process_yolo_detections()
     /// * `tracking` - Time for tracker.match_objects()
-    pub fn record(&mut self, inference: Duration, postprocess: Duration, tracking: Duration) {
+    /// * `dropped` - Frames dropped by the capture thread since the previous processed frame
+    pub fn record(
+        &mut self,
+        inference: Duration,
+        postprocess: Duration,
+        tracking: Duration,
+        dropped: u64,
+    ) {
         self.inference_total += inference;
         self.postprocess_total += postprocess;
         self.tracking_total += tracking;
+        self.dropped_total += dropped;
         self.frame_count += 1;
 
         if self.frame_count >= self.interval {
@@ -57,13 +68,14 @@ impl PerfStats {
         };
 
         println!(
-            "[PerfStats] Last {} frames avg: inference={:.2}ms, postprocess={:.2}ms, tracking={:.2}ms | total={:.2}ms (~{:.1} FPS)",
+            "[PerfStats] Last {} frames avg: inference={:.2}ms, postprocess={:.2}ms, tracking={:.2}ms | total={:.2}ms (~{:.1} FPS) | dropped={}",
             self.frame_count,
             avg_inference,
             avg_postprocess,
             avg_tracking,
             avg_total,
-            estimated_fps
+            estimated_fps,
+            self.dropped_total
         );
 
         // Reset
@@ -71,6 +83,7 @@ impl PerfStats {
         self.inference_total = Duration::ZERO;
         self.postprocess_total = Duration::ZERO;
         self.tracking_total = Duration::ZERO;
+        self.dropped_total = 0;
     }
 }
 

--- a/src/lib/tracker/tracker.rs
+++ b/src/lib/tracker/tracker.rs
@@ -16,6 +16,15 @@ pub trait TrackerEngineSimple {
         confidences: &[f32],
     ) -> Result<(), TrackerError>;
     fn get_objects(&self) -> &HashMap<Uuid, SimpleBlob>;
+    /// Rebuilds every live track for the real interval since the previous
+    /// processed frame. Must be called before `match_objects` on every frame,
+    /// including frames without detections, which carry no dt of their own
+    fn set_dt(&mut self, dt: f32);
+    /// Expire tracks by unmatched time instead of by frame count
+    fn set_max_lost_seconds(&mut self, seconds: f32);
+    fn get_max_lost_seconds(&self) -> Option<f32>;
+    /// Frame-count limit, in effect only while `get_max_lost_seconds` is `None`
+    fn get_max_no_match(&self) -> usize;
 }
 
 /// Trait for BlobBBox trackers
@@ -26,6 +35,15 @@ pub trait TrackerEngineBBox {
         confidences: &[f32],
     ) -> Result<(), TrackerError>;
     fn get_objects(&self) -> &HashMap<Uuid, BlobBBox>;
+    /// Rebuilds every live track for the real interval since the previous
+    /// processed frame. Must be called before `match_objects` on every frame,
+    /// including frames without detections, which carry no dt of their own
+    fn set_dt(&mut self, dt: f32);
+    /// Expire tracks by unmatched time instead of by frame count
+    fn set_max_lost_seconds(&mut self, seconds: f32);
+    fn get_max_lost_seconds(&self) -> Option<f32>;
+    /// Frame-count limit, in effect only while `get_max_lost_seconds` is `None`
+    fn get_max_no_match(&self) -> usize;
 }
 
 impl TrackerEngineSimple for IoUTracker<SimpleBlob> {
@@ -38,6 +56,18 @@ impl TrackerEngineSimple for IoUTracker<SimpleBlob> {
     }
     fn get_objects(&self) -> &HashMap<Uuid, SimpleBlob> {
         &self.objects
+    }
+    fn set_dt(&mut self, dt: f32) {
+        IoUTracker::set_dt(self, dt)
+    }
+    fn set_max_lost_seconds(&mut self, seconds: f32) {
+        IoUTracker::set_max_lost_seconds(self, seconds)
+    }
+    fn get_max_lost_seconds(&self) -> Option<f32> {
+        IoUTracker::get_max_lost_seconds(self)
+    }
+    fn get_max_no_match(&self) -> usize {
+        IoUTracker::get_max_no_match(self)
     }
 }
 
@@ -52,6 +82,18 @@ impl TrackerEngineSimple for ByteTracker<SimpleBlob> {
     fn get_objects(&self) -> &HashMap<Uuid, SimpleBlob> {
         &self.objects
     }
+    fn set_dt(&mut self, dt: f32) {
+        ByteTracker::set_dt(self, dt)
+    }
+    fn set_max_lost_seconds(&mut self, seconds: f32) {
+        ByteTracker::set_max_lost_seconds(self, seconds)
+    }
+    fn get_max_lost_seconds(&self) -> Option<f32> {
+        ByteTracker::get_max_lost_seconds(self)
+    }
+    fn get_max_no_match(&self) -> usize {
+        ByteTracker::get_max_disappeared(self)
+    }
 }
 
 impl TrackerEngineBBox for IoUTracker<BlobBBox> {
@@ -65,6 +107,18 @@ impl TrackerEngineBBox for IoUTracker<BlobBBox> {
     fn get_objects(&self) -> &HashMap<Uuid, BlobBBox> {
         &self.objects
     }
+    fn set_dt(&mut self, dt: f32) {
+        IoUTracker::set_dt(self, dt)
+    }
+    fn set_max_lost_seconds(&mut self, seconds: f32) {
+        IoUTracker::set_max_lost_seconds(self, seconds)
+    }
+    fn get_max_lost_seconds(&self) -> Option<f32> {
+        IoUTracker::get_max_lost_seconds(self)
+    }
+    fn get_max_no_match(&self) -> usize {
+        IoUTracker::get_max_no_match(self)
+    }
 }
 
 impl TrackerEngineBBox for ByteTracker<BlobBBox> {
@@ -77,6 +131,18 @@ impl TrackerEngineBBox for ByteTracker<BlobBBox> {
     }
     fn get_objects(&self) -> &HashMap<Uuid, BlobBBox> {
         &self.objects
+    }
+    fn set_dt(&mut self, dt: f32) {
+        ByteTracker::set_dt(self, dt)
+    }
+    fn set_max_lost_seconds(&mut self, seconds: f32) {
+        ByteTracker::set_max_lost_seconds(self, seconds)
+    }
+    fn get_max_lost_seconds(&self) -> Option<f32> {
+        ByteTracker::get_max_lost_seconds(self)
+    }
+    fn get_max_no_match(&self) -> usize {
+        ByteTracker::get_max_disappeared(self)
     }
 }
 
@@ -120,6 +186,7 @@ impl<T: TrackerEngineSimple> TrackerSimple<T> {
         &mut self,
         detections: &mut Detections,
         current_second: f32,
+        dt: f32,
     ) -> Result<(), TrackerError> {
         let blobs = match &mut detections.blobs {
             DetectionBlobs::Simple(b) => b,
@@ -130,6 +197,9 @@ impl<T: TrackerEngineSimple> TrackerSimple<T> {
             }
         };
 
+        // Existing tracks must move and age over the real interval even when this
+        // frame has no detections to carry it
+        self.engine.set_dt(dt);
         self.engine.match_objects(blobs, &detections.confidences)?;
 
         // Update extra information for each object
@@ -186,6 +256,7 @@ impl<T: TrackerEngineBBox> TrackerBBox<T> {
         &mut self,
         detections: &mut Detections,
         current_second: f32,
+        dt: f32,
     ) -> Result<(), TrackerError> {
         let blobs = match &mut detections.blobs {
             DetectionBlobs::BBox(b) => b,
@@ -196,6 +267,9 @@ impl<T: TrackerEngineBBox> TrackerBBox<T> {
             }
         };
 
+        // Existing tracks must move and age over the real interval even when this
+        // frame has no detections to carry it
+        self.engine.set_dt(dt);
         self.engine.match_objects(blobs, &detections.confidences)?;
 
         // Update extra information for each object
@@ -234,17 +308,33 @@ impl<T: TrackerEngineSimple + fmt::Display> fmt::Display for TrackerSimple<T> {
     }
 }
 
-/// Create tracker based on tracker type and Kalman filter type
+/// How long a track survives without detections unless configured otherwise.
+/// For a road camera occlusions are short, and a Kalman prediction 2 s ahead of
+/// a vehicle at highway speed is 50+ m off anyway
+pub const DEFAULT_MAX_LOST_SECONDS: f32 = 2.0;
+
+/// Create tracker based on tracker type and Kalman filter type.
+///
+/// Tracks expire by unmatched time (`max_lost_seconds`, default
+/// `DEFAULT_MAX_LOST_SECONDS`) unless only a frame count (`max_no_match`) was
+/// given: a frame count changes meaning whenever the effective frame rate does
+/// (frame skipping, a throttled detector, a stalled stream), an occlusion does not
 pub fn new_tracker_from_type(
     tracker_type: &str,
     kalman_filter: KalmanFilterType,
     max_no_match: Option<usize>,
+    max_lost_seconds: Option<f32>,
     iou_threshold: Option<f32>,
 ) -> Box<dyn TrackerTrait> {
+    let max_lost_seconds = match (max_lost_seconds, max_no_match) {
+        (Some(seconds), _) => Some(seconds),
+        (None, Some(_)) => None,
+        (None, None) => Some(DEFAULT_MAX_LOST_SECONDS),
+    };
     let max_no_match = max_no_match.unwrap_or(60);
     let iou_threshold = iou_threshold.unwrap_or(0.3);
 
-    match (tracker_type, kalman_filter) {
+    let mut tracker: Box<dyn TrackerTrait> = match (tracker_type, kalman_filter) {
         ("iou_naive", KalmanFilterType::BBox) => Box::new(
             TrackerBBox::<IoUTracker<BlobBBox>>::new_iou(max_no_match, iou_threshold),
         ),
@@ -291,16 +381,27 @@ pub fn new_tracker_from_type(
                 iou_threshold,
             ))
         }
+    };
+    if let Some(seconds) = max_lost_seconds {
+        tracker.set_max_lost_seconds(seconds);
     }
+    tracker
 }
 
 /// Common trait for all tracker types (both SimpleBlob and BlobBBox based)
 pub trait TrackerTrait {
+    /// Matches detections to tracks. `dt` is the real interval in seconds since
+    /// the previous processed frame; `current_second` is the frame timestamp
     fn match_objects(
         &mut self,
         detections: &mut Detections,
         current_second: f32,
+        dt: f32,
     ) -> Result<(), TrackerError>;
+    /// Expire tracks by unmatched time instead of by frame count
+    fn set_max_lost_seconds(&mut self, seconds: f32);
+    /// Time-based expiry limit, `None` while tracks expire by frame count
+    fn get_max_lost_seconds(&self) -> Option<f32>;
     fn get_objects_extra(&self) -> &HashMap<Uuid, ObjectExtra>;
     fn get_object_extra_mut(&mut self, object_id: &Uuid) -> Option<&mut ObjectExtra>;
     /// Returns tracked objects as TrackedBlob enum (works for both centroid and bbox tracking)
@@ -321,8 +422,17 @@ impl<T: TrackerEngineSimple> TrackerTrait for TrackerSimple<T> {
         &mut self,
         detections: &mut Detections,
         current_second: f32,
+        dt: f32,
     ) -> Result<(), TrackerError> {
-        self.match_objects(detections, current_second)
+        self.match_objects(detections, current_second, dt)
+    }
+
+    fn set_max_lost_seconds(&mut self, seconds: f32) {
+        self.engine.set_max_lost_seconds(seconds)
+    }
+
+    fn get_max_lost_seconds(&self) -> Option<f32> {
+        self.engine.get_max_lost_seconds()
     }
 
     fn get_objects_extra(&self) -> &HashMap<Uuid, ObjectExtra> {
@@ -374,8 +484,12 @@ impl<T: TrackerEngineSimple> TrackerTrait for TrackerSimple<T> {
             .last()
             .unwrap_or("unknown"); // Get last path segment
         format!(
-            "Centroid tracker (4D Kalman: x, y, vx, vy) with {} engine",
-            engine_name
+            "Centroid tracker (4D Kalman: x, y, vx, vy) with {} engine, tracks expire after {}",
+            engine_name,
+            expiry_description(
+                self.engine.get_max_lost_seconds(),
+                self.engine.get_max_no_match()
+            )
         )
     }
 }
@@ -385,8 +499,17 @@ impl<T: TrackerEngineBBox> TrackerTrait for TrackerBBox<T> {
         &mut self,
         detections: &mut Detections,
         current_second: f32,
+        dt: f32,
     ) -> Result<(), TrackerError> {
-        self.match_objects(detections, current_second)
+        self.match_objects(detections, current_second, dt)
+    }
+
+    fn set_max_lost_seconds(&mut self, seconds: f32) {
+        self.engine.set_max_lost_seconds(seconds)
+    }
+
+    fn get_max_lost_seconds(&self) -> Option<f32> {
+        self.engine.get_max_lost_seconds()
     }
 
     fn get_objects_extra(&self) -> &HashMap<Uuid, ObjectExtra> {
@@ -438,9 +561,21 @@ impl<T: TrackerEngineBBox> TrackerTrait for TrackerBBox<T> {
             .last()
             .unwrap_or("unknown"); // Get last path segment
         format!(
-            "BBox tracker (8D Kalman: x, y, w, h, vx, vy, vw, vh) with {} engine",
-            engine_name
+            "BBox tracker (8D Kalman: x, y, w, h, vx, vy, vw, vh) with {} engine, tracks expire after {}",
+            engine_name,
+            expiry_description(
+                self.engine.get_max_lost_seconds(),
+                self.engine.get_max_no_match()
+            )
         )
+    }
+}
+
+/// "2 s unmatched" or "60 frames unmatched", whichever rule is in effect
+fn expiry_description(max_lost_seconds: Option<f32>, max_no_match: usize) -> String {
+    match max_lost_seconds {
+        Some(seconds) => format!("{} s unmatched", seconds),
+        None => format!("{} frames unmatched", max_no_match),
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,7 +23,7 @@ mod settings;
 use settings::AppSettings;
 
 mod video_capture;
-use video_capture::{ThreadedFrame, VideoSource};
+use video_capture::{ThreadedFrame, VideoSource, frame_channel};
 
 use lib::publisher::RedisConnection;
 
@@ -264,13 +264,11 @@ fn run(
     }
 
     /* Start capture loop */
-    let (tx_capture, rx_capture): (
-        mpsc::SyncSender<ThreadedFrame>,
-        mpsc::Receiver<ThreadedFrame>,
-    ) = mpsc::sync_channel(0);
-    // @experimental
-    let skip_every_n_frame: u64 = 2;
     let live_source = video_source.is_live();
+    // A file is consumed frame by frame; a live source hands over its newest
+    // frame and drops the ones a slow detector did not get to (see frame_channel)
+    let (tx_capture, rx_capture) = frame_channel(live_source);
+    let skip_every_n_frame: u64 = settings.input.process_every_nth_frame.unwrap_or(2).max(1) as u64;
     thread::spawn(move || {
         let mut frame_idx: u64 = 0;
         let mut processed_frames: u32 = 0;
@@ -310,13 +308,10 @@ fn run(
                 timestamp,
             };
 
-            match tx_capture.send(frame) {
-                Ok(_) => {}
-                Err(_err) => {
-                    // Closed channel?
-                    // println!("Error on send frame to detection thread: {}", _err)
-                }
-            };
+            if tx_capture.send(frame).is_err() {
+                // Detection thread is gone, nobody will take frames any more
+                break;
+            }
 
             processed_frames += 1;
             if report_mode && total_frames > 0.0 && processed_frames % 100 == 0 {
@@ -379,8 +374,25 @@ fn run(
     // Nominal interval between the frames the tracker actually sees: every N-th
     // frame is processed, so the effective rate is fps / N, not fps
     let nominal_dt: f64 = skip_every_n_frame as f64 / fps as f64;
+    // Longest interval the Kalman filters are asked to bridge. With time-based
+    // expiry there is no point predicting further than a track is allowed to
+    // live; with frame-based expiry fall back to a fixed multiple of the nominal step
+    let max_dt: f64 = match tracker.get_max_lost_seconds() {
+        Some(seconds) => (seconds as f64).max(nominal_dt),
+        None => nominal_dt * 10.0,
+    };
     // Timestamp of the last frame that reached the tracker
     let mut prev_tracked_ts: Option<f64> = None;
+    // Frames the capture thread dropped, as of the previous processed frame
+    let mut dropped_seen: u64 = 0;
+    println!(
+        "Frame timing: {} source, 1 of every {} frames processed, nominal dt {:.4} s, dt clamped to [{:.4}, {:.2}] s",
+        if live_source { "live" } else { "file" },
+        skip_every_n_frame,
+        nominal_dt,
+        nominal_dt * 0.25,
+        max_dt
+    );
 
     /* Performance stats (optional) */
     let perf_stats_interval = settings.detection.perf_stats_interval;
@@ -403,7 +415,7 @@ fn run(
 
     /* Can't create colors as const/static currently */
     let mut first_frame: Option<lib::cv::RawFrame> = None;
-    for received in rx_capture {
+    while let Some(received) = rx_capture.recv() {
         if report_mode && first_frame.is_none() {
             first_frame = Some(received.frame.clone());
         }
@@ -430,10 +442,12 @@ fn run(
         // tracked frame rather than 1/fps: a slow detector, a decoder stall or
         // frames dropped by the source all stretch it, and a filter built for the
         // nominal step then predicts a whole stride short and loses the match.
-        // Clamped so that a long stall can't make it extrapolate for seconds
+        // The lower bound guards against a zero step (Q has dt^4 in it), the
+        // upper one against extrapolating past the point where a track would
+        // have expired anyway
         let dt: f64 = match prev_tracked_ts {
             Some(prev) if received.timestamp > prev => {
-                (received.timestamp - prev).clamp(nominal_dt * 0.25, nominal_dt * 10.0)
+                (received.timestamp - prev).clamp(nominal_dt * 0.25, max_dt)
             }
             _ => nominal_dt,
         };
@@ -455,7 +469,7 @@ fn run(
         /* Tracking: match detections to existing tracks */
         let t_tracking = Timer::start();
         let relative_time = received.timestamp as f32;
-        match tracker.match_objects(&mut tmp_detections, relative_time) {
+        match tracker.match_objects(&mut tmp_detections, relative_time, dt as f32) {
             Ok(_) => {}
             Err(err) => {
                 println!("Can't match objects due the error: {:?}", err);
@@ -467,7 +481,14 @@ fn run(
 
         /* Record performance stats */
         if let Some(ref mut stats) = perf_stats {
-            stats.record(inference_time, postprocess_time, tracking_time);
+            let dropped_total = rx_capture.dropped();
+            stats.record(
+                inference_time,
+                postprocess_time,
+                tracking_time,
+                dropped_total - dropped_seen,
+            );
+            dropped_seen = dropped_total;
         }
 
         /* Dataset collection - save raw frame and annotations */
@@ -779,6 +800,7 @@ fn main() {
         &app_settings.tracking.typ.as_deref().unwrap_or("iou_naive"),
         kalman_filter,
         app_settings.tracking.max_no_match,
+        app_settings.tracking.max_lost_seconds,
         app_settings.tracking.iou_threshold,
     );
     println!("Tracker is:\n\t{}", tracker);

--- a/src/settings/settings.rs
+++ b/src/settings/settings.rs
@@ -57,6 +57,10 @@ pub struct AppSettings {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct InputSettings {
     pub video_src: String,
+    /// Run detection and tracking on every N-th decoded frame. Default is 2.
+    /// The tracker is told the real interval between the frames it sees, so this
+    /// only trades accuracy for CPU; it never changes what a second means
+    pub process_every_nth_frame: Option<u32>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -90,7 +94,12 @@ pub struct TrackingSettings {
     pub max_points_in_track: usize,
     // Either "centroid" or "bbox". Default is "centroid"
     pub kalman_filter: Option<String>,
-    // Maximum number of frames to keep tracking an object without new detections. Default is 60
+    // Maximum time in seconds to keep tracking an object without new detections. Default is 2.0.
+    // Takes precedence over `max_no_match`: a frame count changes meaning whenever the effective
+    // frame rate does (frame skipping, a throttled detector, a stalled stream), an occlusion does not
+    pub max_lost_seconds: Option<f32>,
+    // Maximum number of frames to keep tracking an object without new detections.
+    // Only used when `max_lost_seconds` is not set
     pub max_no_match: Option<usize>,
     // IoU threshold for matching detections to tracks. Default is 0.3
     pub iou_threshold: Option<f32>,

--- a/src/video_capture/capture.rs
+++ b/src/video_capture/capture.rs
@@ -149,7 +149,6 @@ impl Drop for VideoSource {
     }
 }
 
-
 fn detect_source_kind(src: &str) -> SourceKind {
     if src.starts_with("rtsp://") || src.starts_with("rtsps://") {
         SourceKind::Rtsp

--- a/src/video_capture/frame.rs
+++ b/src/video_capture/frame.rs
@@ -1,3 +1,7 @@
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::mpsc::{Receiver, SyncSender};
+use std::sync::{Arc, Condvar, Mutex, mpsc};
+
 use crate::lib::cv::RawFrame;
 
 pub struct ThreadedFrame {
@@ -6,4 +10,213 @@ pub struct ThreadedFrame {
     /// wall clock for live sources. f64 so that the interval between two frames
     /// stays exact after days of uptime; f32 loses ~10 ms per step past ~1e5 s.
     pub timestamp: f64,
+}
+
+/// Hands frames from the capture thread to the detection thread.
+///
+/// A file is consumed losslessly: the capture thread waits for the detector, so
+/// every N-th frame is processed and report mode stays deterministic. A live
+/// source never waits: the newest frame replaces the one the detector has not
+/// taken yet. A detector that falls behind then sees real, longer intervals
+/// between the frames it processes instead of a growing backlog of stale ones,
+/// the decoder is never blocked on the pipe, and latency stays bounded by one
+/// frame.
+pub fn frame_channel(live: bool) -> (FrameSender, FrameReceiver) {
+    if live {
+        let slot = Arc::new(LatestFrameSlot::default());
+        (
+            FrameSender::Latest(slot.clone()),
+            FrameReceiver::Latest(slot),
+        )
+    } else {
+        let (tx, rx) = mpsc::sync_channel(0);
+        (FrameSender::Lossless(tx), FrameReceiver::Lossless(rx))
+    }
+}
+
+pub enum FrameSender {
+    Lossless(SyncSender<ThreadedFrame>),
+    Latest(Arc<LatestFrameSlot>),
+}
+
+pub enum FrameReceiver {
+    Lossless(Receiver<ThreadedFrame>),
+    Latest(Arc<LatestFrameSlot>),
+}
+
+impl FrameSender {
+    /// Hands a frame over. Blocks until the detector takes it for a file; for a
+    /// live source returns at once, replacing a frame the detector has not taken
+    /// yet. `Err` means the receiving side is gone.
+    pub fn send(&self, frame: ThreadedFrame) -> Result<(), ThreadedFrame> {
+        match self {
+            FrameSender::Lossless(tx) => tx.send(frame).map_err(|e| e.0),
+            FrameSender::Latest(slot) => slot.push(frame),
+        }
+    }
+
+    /// Frames replaced before the detector took them. Always 0 for a file.
+    pub fn dropped(&self) -> u64 {
+        match self {
+            FrameSender::Lossless(_) => 0,
+            FrameSender::Latest(slot) => slot.dropped(),
+        }
+    }
+}
+
+impl Drop for FrameSender {
+    fn drop(&mut self) {
+        if let FrameSender::Latest(slot) = self {
+            slot.close();
+        }
+    }
+}
+
+impl Drop for FrameReceiver {
+    fn drop(&mut self) {
+        if let FrameReceiver::Latest(slot) = self {
+            // Lets the capture thread notice that nobody will take frames any more
+            slot.close();
+        }
+    }
+}
+
+impl FrameReceiver {
+    /// Next frame to process. `None` once the sender is gone and nothing is left.
+    pub fn recv(&self) -> Option<ThreadedFrame> {
+        match self {
+            FrameReceiver::Lossless(rx) => rx.recv().ok(),
+            FrameReceiver::Latest(slot) => slot.take(),
+        }
+    }
+
+    /// Frames replaced before the detector took them, so far. Always 0 for a file.
+    pub fn dropped(&self) -> u64 {
+        match self {
+            FrameReceiver::Lossless(_) => 0,
+            FrameReceiver::Latest(slot) => slot.dropped(),
+        }
+    }
+}
+
+/// Single-frame mailbox: the newest frame wins.
+#[derive(Default)]
+pub struct LatestFrameSlot {
+    state: Mutex<SlotState>,
+    ready: Condvar,
+    dropped: AtomicU64,
+}
+
+#[derive(Default)]
+struct SlotState {
+    frame: Option<ThreadedFrame>,
+    closed: bool,
+}
+
+impl LatestFrameSlot {
+    fn push(&self, frame: ThreadedFrame) -> Result<(), ThreadedFrame> {
+        let mut state = self.state.lock().expect("Frame slot is poisoned [Mutex]");
+        if state.closed {
+            return Err(frame);
+        }
+        if state.frame.replace(frame).is_some() {
+            self.dropped.fetch_add(1, Ordering::Relaxed);
+        }
+        self.ready.notify_one();
+        Ok(())
+    }
+
+    fn take(&self) -> Option<ThreadedFrame> {
+        let mut state = self.state.lock().expect("Frame slot is poisoned [Mutex]");
+        loop {
+            if let Some(frame) = state.frame.take() {
+                return Some(frame);
+            }
+            if state.closed {
+                return None;
+            }
+            state = self
+                .ready
+                .wait(state)
+                .expect("Frame slot is poisoned [Mutex]");
+        }
+    }
+
+    fn close(&self) {
+        let mut state = self.state.lock().expect("Frame slot is poisoned [Mutex]");
+        state.closed = true;
+        self.ready.notify_all();
+    }
+
+    fn dropped(&self) -> u64 {
+        self.dropped.load(Ordering::Relaxed)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::thread;
+    use std::time::Duration;
+
+    fn frame(ts: f64) -> ThreadedFrame {
+        ThreadedFrame {
+            frame: RawFrame {
+                data: vec![],
+                width: 0,
+                height: 0,
+            },
+            timestamp: ts,
+        }
+    }
+
+    #[test]
+    fn latest_slot_keeps_only_the_newest_frame() {
+        let (tx, rx) = frame_channel(true);
+        assert!(tx.send(frame(1.0)).is_ok());
+        assert!(tx.send(frame(2.0)).is_ok());
+        assert!(tx.send(frame(3.0)).is_ok());
+        assert_eq!(rx.recv().unwrap().timestamp, 3.0);
+        assert_eq!(rx.dropped(), 2);
+        assert_eq!(tx.dropped(), 2);
+    }
+
+    #[test]
+    fn latest_slot_waits_for_a_frame_and_ends_on_close() {
+        let (tx, rx) = frame_channel(true);
+        let producer = thread::spawn(move || {
+            thread::sleep(Duration::from_millis(20));
+            assert!(tx.send(frame(1.0)).is_ok());
+            thread::sleep(Duration::from_millis(20));
+            // tx dropped here: the receiver must wake up and stop
+        });
+        assert_eq!(rx.recv().unwrap().timestamp, 1.0);
+        assert!(rx.recv().is_none());
+        producer.join().unwrap();
+        assert_eq!(rx.dropped(), 0);
+    }
+
+    #[test]
+    fn latest_slot_refuses_frames_after_receiver_is_gone() {
+        let (tx, rx) = frame_channel(true);
+        drop(rx);
+        assert!(tx.send(frame(1.0)).is_err());
+    }
+
+    #[test]
+    fn lossless_channel_delivers_every_frame_in_order() {
+        let (tx, rx) = frame_channel(false);
+        let producer = thread::spawn(move || {
+            for i in 0..5 {
+                assert!(tx.send(frame(i as f64)).is_ok());
+            }
+        });
+        let mut seen = vec![];
+        while let Some(f) = rx.recv() {
+            seen.push(f.timestamp);
+        }
+        producer.join().unwrap();
+        assert_eq!(seen, vec![0.0, 1.0, 2.0, 3.0, 4.0]);
+        assert_eq!(rx.dropped(), 0);
+    }
 }


### PR DESCRIPTION
Follow-up to the frame-timestamp fix, on [mot-rs 0.6.0](https://github.com/LdDl/mot-rs/releases/tag/v0.6.0)

- `max_lost_seconds` (default 2.0) replaces `max_no_match`: a frame count changes meaning with frame skipping, a throttled detector or a stalled stream, an occlusion does not. `max_no_match` still works when set explicitly.
- `process_every_nth_frame` moved from a hardcoded 2 into `[input]`; nominal dt derives from it.
- `tracker.set_dt(dt)` before every `match_objects`, so frames without detections advance and age tracks over the real interval.
- dt upper clamp is `max_lost_seconds` instead of x10 nominal - a 1–2 s stall is predicted over its real length.
- Live sources use a latest-frame slot instead of a blocking channel: no backlog in ffmpeg/gst, bounded latency, dropped frames counted in PerfStats. Files stay lossless.
