### PR TITLE
Generate equipment id when the config has any

### DIFF
--- a/data/conf.toml
+++ b/data/conf.toml
@@ -38,8 +38,9 @@
     kalman_filter = "bbox"
 
 [equipment_info]
-    # Just field for future identification of application. Could be any string.
-    # I've used https://www.uuidgenerator.net/version4 for ID generation
+    # Identifies this installation point in everything the app publishes (stats, Redis).
+    # Could be any string. I've used https://www.uuidgenerator.net/version4 for ID generation.
+    # Any non-empty string. Leave it empty and a UUID is generated on first start and written back here.
     id = "1e23985f-1fa3-45d0-a365-2d8525a23ddd"
 
 # Define parameters for zones of intereset

--- a/data/conf2.toml
+++ b/data/conf2.toml
@@ -33,8 +33,9 @@
     max_points_in_track = 100
 
 [equipment_info]
-    # Just field for future identification of application. Could be any string.
-    # I've used https://www.uuidgenerator.net/version4 for ID generation
+    # Identifies this installation point in everything the app publishes (stats, Redis).
+    # Could be any string. I've used https://www.uuidgenerator.net/version4 for ID generation.
+    # Any non-empty string. Leave it empty and a UUID is generated on first start and written back here.
     id = "1e23985f-1fa3-45d0-a365-2d8525a23ddd"
 
 # Define parameters for zones of intereset

--- a/src/main.rs
+++ b/src/main.rs
@@ -762,10 +762,24 @@ fn main() {
             "./data/conf.toml"
         }
     };
-    let app_settings = AppSettings::new(path_to_config).unwrap_or_else(|e| {
+    let mut app_settings = AppSettings::new(path_to_config).unwrap_or_else(|e| {
         eprintln!("Failed to load settings '{}': {}", path_to_config, e);
         std::process::exit(1);
     });
+    match app_settings.ensure_equipment_id(path_to_config) {
+        Ok(Some(id)) => println!(
+            "Equipment id was blank, generated '{}' and saved it to '{}'",
+            id, path_to_config
+        ),
+        Ok(None) => {}
+        Err(e) => {
+            eprintln!(
+                "Can't save generated equipment id to '{}': {}",
+                path_to_config, e
+            );
+            std::process::exit(1);
+        }
+    }
     println!("Settings are:\n\t{}", app_settings);
 
     let kalman_filter: KalmanFilterType = app_settings

--- a/src/settings/settings.rs
+++ b/src/settings/settings.rs
@@ -46,6 +46,9 @@ pub struct AppSettings {
     pub debug: Option<DebugSettings>,
     pub detection: DetectionSettings,
     pub tracking: TrackingSettings,
+    /// Identifies the installation point in everything the app publishes.
+    /// Optional in the file: a blank one is generated and written back on start
+    #[serde(default)]
     pub equipment_info: EquipmentInfo,
     pub road_lanes: Option<Vec<RoadLanesSettings>>,
     pub worker: WorkerSettings,
@@ -98,7 +101,7 @@ pub struct TrackingSettings {
     pub iou_threshold: Option<f32>,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
+#[derive(Serialize, Deserialize, Debug, Clone, Default)]
 pub struct EquipmentInfo {
     pub id: String,
 }
@@ -556,6 +559,22 @@ impl AppSettings {
     /// that did not change are not touched at all. `[[road_lanes]]` is replaced
     /// as a whole: it is produced by the UI and carries no hand-written
     /// comments. A missing file is created from a plain dump
+    /// Gives the equipment a generated id when the file has none (or a blank
+    /// one) and writes it back at once, so it survives restarts. The id names
+    /// the installation point, not the board, so it is never derived from
+    /// hardware. Returns the generated id, `None` when the file already had one
+    pub fn ensure_equipment_id(
+        &mut self,
+        filename: &str,
+    ) -> Result<Option<String>, Box<dyn Error>> {
+        if !self.equipment_info.id.trim().is_empty() {
+            return Ok(None);
+        }
+        let id = uuid::Uuid::new_v4().to_string();
+        self.equipment_info.id = id.clone();
+        self.save(filename)?;
+        Ok(Some(id))
+    }
     pub fn save(&self, filename: &str) -> Result<(), Box<dyn Error>> {
         let dump = toml::to_string(self)?;
         let output = match fs::read_to_string(filename) {
@@ -803,5 +822,56 @@ mod tests {
         let reloaded = AppSettings::new(&fresh).unwrap();
         let _ = fs::remove_file(&fresh);
         assert_eq!(reloaded.equipment_info.id, "old-id");
+    }
+
+    #[test]
+    fn blank_equipment_id_is_generated_once_and_persisted() {
+        let file = TempConfig::new("blank_id");
+        let text = fs::read_to_string(&file.0)
+            .unwrap()
+            .replace("id = \"old-id\"", "id = \"  \"");
+        fs::write(&file.0, text).unwrap();
+        let mut settings = AppSettings::new(&file.0).unwrap();
+        let generated = settings
+            .ensure_equipment_id(&file.0)
+            .unwrap()
+            .expect("blank id must be generated");
+        assert!(uuid::Uuid::parse_str(&generated).is_ok());
+        assert_eq!(settings.equipment_info.id, generated);
+
+        let text = fs::read_to_string(&file.0).unwrap();
+        assert!(text.contains(&format!("id = \"{generated}\"")), "{text}");
+        assert!(
+            text.contains("# Generated once, identifies the installation point"),
+            "{text}"
+        );
+        // Second start keeps it
+        let mut reloaded = AppSettings::new(&file.0).unwrap();
+        assert_eq!(reloaded.ensure_equipment_id(&file.0).unwrap(), None);
+        assert_eq!(reloaded.equipment_info.id, generated);
+    }
+
+    #[test]
+    fn missing_equipment_section_is_created() {
+        let file = TempConfig::new("no_equipment");
+        let text = fs::read_to_string(&file.0).unwrap();
+        let start = text.find("[equipment_info]").unwrap();
+        let end = text.find("[[road_lanes]]").unwrap();
+        // Drop the whole section, including its comment
+        let text = format!(
+            "{}{}",
+            &text[..text[..start].rfind("\n\n").unwrap() + 2],
+            &text[end..]
+        );
+        fs::write(&file.0, &text).unwrap();
+        let mut settings = AppSettings::new(&file.0).unwrap();
+        assert!(settings.equipment_info.id.is_empty());
+        let generated = settings.ensure_equipment_id(&file.0).unwrap().unwrap();
+        let saved = fs::read_to_string(&file.0).unwrap();
+        assert!(saved.contains("[equipment_info]"), "{saved}");
+        assert_eq!(
+            AppSettings::new(&file.0).unwrap().equipment_info.id,
+            generated
+        );
     }
 }


### PR DESCRIPTION
`[equipment_info].id` had to be placed by hand.

It is now optional: a missing section or a blank id is replaced by a generated UUID v4 on start and written back to the config right away, so it stays stable across restarts. Any non-empty string still works.
