### PR TITLE
NDJSON for verbose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ data/sample_960_540.mp4
 data/conf_test.toml
 collected_dataset/
 benchmarking.prof
+logs/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -746,6 +746,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "98b0cc327b5bc766e7fda9c9260cc0fa81b43a8e240440422dff70788e3f9ef1"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1756,6 +1765,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1670343e58806300d87950e3401e820b519b9384281bbabfb15e3636689ffd69"
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "matrixmultiply"
 version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1949,6 +1967,15 @@ name = "noop_proc_macro"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "num-bigint"
@@ -2614,6 +2641,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c6a884d2998352bb4daf0183589aec883f16a6da1f4dde84d8e2e9a5409a1ce"
 
 [[package]]
+name = "rolling-file"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8395b4f860856b740f20a296ea2cd4d823e81a2658cf05ef61be22916026a906"
+dependencies = [
+ "chrono",
+]
+
+[[package]]
 name = "rust-road-traffic"
 version = "0.3.1"
 dependencies = [
@@ -2632,12 +2668,16 @@ dependencies = [
  "png",
  "rand",
  "redis",
+ "rolling-file",
  "serde",
  "serde_json",
  "static-files 0.2.5",
  "tokio",
  "toml",
  "toml_edit",
+ "tracing",
+ "tracing-appender",
+ "tracing-subscriber",
  "turbojpeg",
  "utoipa",
  "utoipa-rapidoc",
@@ -2838,6 +2878,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2952,6 +3001,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "symlink"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3052,6 +3107,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.108",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -3214,9 +3278,9 @@ checksum = "df8b2b54733674ad286d16267dcfc7a71ed5c776e4ac7aa3c3e2561f7c637bf2"
 
 [[package]]
 name = "tracing"
-version = "0.1.41"
+version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "log",
  "pin-project-lite",
@@ -3225,10 +3289,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-attributes"
-version = "0.1.30"
+name = "tracing-appender"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
+checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
+dependencies = [
+ "crossbeam-channel",
+ "symlink",
+ "thiserror 2.0.17",
+ "time",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3237,11 +3314,54 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.34"
+version = "0.1.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d12581f227e93f094d3af2ae690a574abb8a2b9b7a96e7cfe9647b2b617678"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-serde"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
+dependencies = [
+ "serde",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "serde",
+ "serde_json",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+ "tracing-serde",
 ]
 
 [[package]]
@@ -3405,6 +3525,12 @@ dependencies = [
  "num-traits",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,11 @@ uuid = { version = "1.18.1", features = ["serde", "v4"] }
 nalgebra = "0.34.1"
 toml = "0.9.8"
 toml_edit = "0.23.7"
+# Logging: NDJSON to stdout + rotated file
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
+tracing-appender = "0.2.4"
+rolling-file = "0.2"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 chrono = { version = "0.4", features = ["serde"] }

--- a/README.md
+++ b/README.md
@@ -335,6 +335,29 @@ Locally you can access Swagger UI documentation via http://localhost:42001/api/d
         reset_data_milliseconds = 30000
     ```
 
+13. Logging
+
+    Logs are NDJSON (one JSON object per line) on stdout and, by default, in `./logs/rust-road-traffic.log` next to the config file. Every line carries `level` (`INFO`, `WARN`, `ERROR`), `scope` (`startup`, `capture`, `processing`, `analytics`, `redis`, `rest_api`, `report`, `dataset`) and the message with its fields:
+
+    ```json
+    {"timestamp":"2026-09-07T16:56:01.362275Z","level":"INFO","fields":{"message":"Frame timing","scope":"capture","source":"file","process_every_nth_frame":2,"nominal_dt":0.0667,"dt_min":0.0167,"dt_max":2.0}}
+    ```
+
+    The `[verbose]` section (optional, every key optional) only sets how much and where:
+
+    ```toml
+    [verbose]
+        # "info" (default): regular, warning and error lines. "debug" adds per-frame detail.
+        level = "info"
+        # Relative to the config file's folder. Empty string = stdout only.
+        logs_folder = "./logs"
+        # Rotate daily or at this size (MB); keep this many old files (defaults: 10 MB, 2 files).
+        max_file_size_mb = 10
+        max_files = 2
+    ```
+
+    The `RUST_LOG` environment variable overrides `level`. A folder that can't be written to never stops the app: it logs to stdout only and says why.
+
 ## Virtual lines
 
 This utility supports vehicle counting via two approaches:

--- a/data/conf.toml
+++ b/data/conf.toml
@@ -13,8 +13,18 @@
     # detector that falls behind additionally skips whatever frames it did not get to.
     process_every_nth_frame = 2
 
-[debug]
-    enable = true
+# Logging is always on; this section only sets how much and where. Every key is optional.
+[verbose]
+    # "info" (default): regular, warning and error lines. "debug" adds per-frame detail.
+    # The RUST_LOG environment variable overrides it.
+    level = "info"
+    # Folder for the log file (NDJSON, one JSON object per line). Logs always go to stdout as well.
+    # A relative path is taken from this config file's folder. Empty string = stdout only.
+    logs_folder = "./logs"
+    # The file rotates daily or when it reaches this size (MB); this many old files are kept.
+    # Defaults are 10 MB and 2 files: the target is usually an SBC with an SD card.
+    max_file_size_mb = 10
+    max_files = 2
 
 [detection]
     # Weights file: .weights (Darknet), .onnx (ONNX), .engine/.trt (TensorRT)

--- a/data/conf2.toml
+++ b/data/conf2.toml
@@ -13,8 +13,18 @@
     # detector that falls behind additionally skips whatever frames it did not get to.
     process_every_nth_frame = 2
 
-[debug]
-    enable = true
+# Logging is always on; this section only sets how much and where. Every key is optional.
+[verbose]
+    # "info" (default): regular, warning and error lines. "debug" adds per-frame detail.
+    # The RUST_LOG environment variable overrides it.
+    level = "info"
+    # Folder for the log file (NDJSON, one JSON object per line). Logs always go to stdout as well.
+    # A relative path is taken from this config file's folder. Empty string = stdout only.
+    logs_folder = "./logs"
+    # The file rotates daily or when it reaches this size (MB); this many old files are kept.
+    # Defaults are 10 MB and 2 files: the target is usually an SBC with an SD card.
+    max_file_size_mb = 10
+    max_files = 2
 
 [detection]
     # Weights file: .weights (Darknet), .onnx (ONNX), .engine/.trt (TensorRT)

--- a/src/lib/data_storage/data_storage.rs
+++ b/src/lib/data_storage/data_storage.rs
@@ -1,4 +1,6 @@
+use crate::lib::logging;
 use std::collections::HashMap;
+use tracing::{error, info};
 
 use std::sync::{Arc, Mutex, PoisonError, RwLock};
 
@@ -36,11 +38,10 @@ pub struct DataStorage {
     pub period_start: DateTime<Utc>,
     pub period_end: DateTime<Utc>,
     pub id: String,
-    pub verbose: bool,
 }
 
 impl DataStorage {
-    pub fn new_with_id(_id: String, _verbose: bool) -> Self {
+    pub fn new_with_id(_id: String) -> Self {
         return DataStorage {
             zones: Arc::new(RwLock::new(HashMap::<String, Mutex<Zone>>::new())),
             zone_grid: Arc::new(RwLock::new(ZoneGrid::uninitialized())),
@@ -48,7 +49,6 @@ impl DataStorage {
             period_start: TimeZone::with_ymd_and_hms(&Utc, 1970, 1, 1, 0, 0, 0).unwrap(),
             period_end: TimeZone::with_ymd_and_hms(&Utc, 1970, 1, 1, 0, 0, 0).unwrap(),
             id: _id,
-            verbose: _verbose,
         };
     }
 
@@ -153,63 +153,31 @@ impl DataStorage {
                     }
                     drop(zone);
                 }
-                // Print the OD matrix in a nice table format
-                println!("\n=== Origin-Destination Matrix ===");
-                println!("Equipment ID: {}", self.id);
-                println!("Period: {} to {}", self.period_start, self.period_end);
-                if zone_keys.is_empty() {
-                    println!("No zones configured.");
-                    return Ok(());
-                }
-                // Print header
-                print!("{:>12}", "FROM \\ TO");
-                for to_key in &zone_keys {
-                    print!("{:>12}", to_key);
-                }
-                println!();
-                // Print separator
-                print!("{:>12}", "----------");
-                for _ in &zone_keys {
-                    print!("{:>12}", "----------");
-                }
-                println!();
-                // Print matrix rows
-                for from_key in &zone_keys {
-                    print!("{:>12}", from_key);
-                    if let Some(from_matrix) = od_matrix.get(from_key) {
-                        for to_key in &zone_keys {
-                            let count = from_matrix.get(to_key).unwrap_or(&0);
-                            print!("{:>12}", count);
-                        }
-                    }
-                    println!();
-                }
-                // Print summary statistics
                 let total_movements: u32 =
                     od_matrix.values().flat_map(|inner| inner.values()).sum();
-                println!("\n=== Summary ===");
-                println!("Total movements: {}", total_movements);
-                // Print top flows
-                let mut flows: Vec<(String, String, u32)> = Vec::new();
+                info!(
+                    scope = logging::SCOPE_ANALYTICS,
+                    equipment_id = %self.id,
+                    period_start = %self.period_start,
+                    period_end = %self.period_end,
+                    zones = zone_keys.len(),
+                    total_movements,
+                    "OD matrix updated"
+                );
                 for (from_key, from_matrix) in &od_matrix {
                     for (to_key, count) in from_matrix {
                         if *count > 0 {
-                            flows.push((from_key.clone(), to_key.clone(), *count));
+                            info!(
+                                scope = logging::SCOPE_ANALYTICS,
+                                from = %from_key,
+                                to = %to_key,
+                                count,
+                                u_turn = from_key == to_key,
+                                "OD flow"
+                            );
                         }
                     }
                 }
-                if !flows.is_empty() {
-                    flows.sort_by(|a, b| b.2.cmp(&a.2)); // Sort by count descending
-                    println!("\nTop flows:");
-                    for (from, to, count) in flows.iter().take(5) {
-                        if from == to {
-                            println!("  {} → {} (U-turns): {} vehicles", from, to, count);
-                        } else {
-                            println!("  {} → {}: {} vehicles", from, to, count);
-                        }
-                    }
-                }
-                println!("=== End OD Matrix ===\n");
             }
             Err(_) => {
                 return Err(DataStorageError::Poison);
@@ -221,15 +189,16 @@ impl DataStorage {
 
 pub type ThreadedDataStorage = Arc<RwLock<DataStorage>>;
 
-pub fn new_datastorage(_id: String, _verbose: bool) -> ThreadedDataStorage {
-    let data_storage = DataStorage::new_with_id(_id, _verbose);
+pub fn new_datastorage(_id: String) -> ThreadedDataStorage {
+    let data_storage = DataStorage::new_with_id(_id);
     Arc::new(RwLock::new(data_storage))
 }
 
-pub fn start_analytics_thread(ds: ThreadedDataStorage, millis: u64, verbose: bool) {
-    if verbose {
-        println!("Analytics data would be refreshed every {} ms", millis);
-    }
+pub fn start_analytics_thread(ds: ThreadedDataStorage, millis: u64) {
+    info!(
+        scope = logging::SCOPE_ANALYTICS,
+        millis, "Analytics refresh thread started"
+    );
 
     thread::spawn(move || {
         let millis_i64 = millis as i64;
@@ -243,16 +212,22 @@ pub fn start_analytics_thread(ds: ThreadedDataStorage, millis: u64, verbose: boo
                     mutex.period_end = last_tm + chrono::Duration::milliseconds(millis_i64);
                     match mutex.update_statistics() {
                         Ok(_) => {
-                            println!("Statistics updated: {}", last_tm);
+                            info!(scope = logging::SCOPE_ANALYTICS, since = %last_tm, "Statistics updated");
                         }
                         Err(_) => {
-                            println!("Can't update statistics due PoisonErr [1]");
+                            error!(
+                                scope = logging::SCOPE_ANALYTICS,
+                                "Can't update statistics: data storage is poisoned"
+                            );
                         }
                     }
                     last_tm = Utc::now();
                 }
                 Err(_) => {
-                    println!("Can't update statistics due PoisonErr [2]");
+                    error!(
+                        scope = logging::SCOPE_ANALYTICS,
+                        "Can't update statistics: data storage lock is poisoned"
+                    );
                 }
             }
             thread::sleep(std::time::Duration::from_millis(millis));

--- a/src/lib/data_storage/data_storage.rs
+++ b/src/lib/data_storage/data_storage.rs
@@ -112,7 +112,7 @@ impl DataStorage {
         };
         Ok(())
     }
-    pub fn print_od_matrix(&self) -> Result<(), DataStorageError> {
+    pub fn log_od_matrix(&self) -> Result<(), DataStorageError> {
         let zones = Arc::clone(&self.zones);
         match zones.read() {
             Ok(zones_guard) => {

--- a/src/lib/dataset_collector.rs
+++ b/src/lib/dataset_collector.rs
@@ -1,5 +1,7 @@
 use crate::lib::cv::{RawFrame, Rect as RectCV};
+use crate::lib::logging;
 use crate::lib::mjpeg_streaming::JpegEncoder;
+use tracing::info;
 
 use std::collections::HashMap;
 use std::fs;
@@ -51,13 +53,13 @@ impl DatasetCollector {
             .map(|(i, name)| (name.clone(), i))
             .collect();
 
-        println!(
-            "[DatasetCollector] Initialized with output_dir: {}",
-            settings.output_dir
-        );
-        println!(
-            "[DatasetCollector] min_track_age: {}, max_captures_per_track: {}, capture_interval: {}",
-            settings.min_track_age, settings.max_captures_per_track, settings.capture_interval
+        info!(
+            scope = logging::SCOPE_DATASET,
+            output_dir = %settings.output_dir,
+            min_track_age = settings.min_track_age,
+            max_captures_per_track = settings.max_captures_per_track,
+            capture_interval = settings.capture_interval,
+            "DatasetCollector initialized"
         );
 
         Ok(Self {
@@ -118,11 +120,12 @@ impl DatasetCollector {
 
         // Debug: log every 100 frames
         if self.frame_counter % 100 == 0 {
-            println!(
-                "[DatasetCollector] Frame {}: {} detections, {} tracked objects",
-                self.frame_counter,
-                bboxes.len(),
-                self.track_states.len()
+            info!(
+                scope = logging::SCOPE_DATASET,
+                frame = self.frame_counter,
+                detections = bboxes.len(),
+                tracked = self.track_states.len(),
+                "DatasetCollector frame"
             );
         }
 
@@ -188,12 +191,13 @@ impl DatasetCollector {
 
         // Debug: log skip reasons every 100 frames
         if self.frame_counter % 100 == 0 && !bboxes.is_empty() {
-            println!(
-                "[DatasetCollector] Skipped: {} young, {} edge. Mature: {}, Triggers: {}",
+            info!(
+                scope = logging::SCOPE_DATASET,
                 skipped_young,
                 skipped_edge,
-                mature_objects.len(),
-                trigger_track_ids.len()
+                mature = mature_objects.len(),
+                triggers = trigger_track_ids.len(),
+                "DatasetCollector filter"
             );
         }
 
@@ -247,12 +251,13 @@ impl DatasetCollector {
             let mut file = fs::File::create(&label_path)?;
             file.write_all(annotations.as_bytes())?;
 
-            println!(
-                "[DatasetCollector] SAVED: {} with {} objects (triggered by {}) -> {}",
-                filename_base,
-                mature_objects.len(),
-                trigger_track_ids.len(),
-                image_path
+            info!(
+                scope = logging::SCOPE_DATASET,
+                file = %filename_base,
+                objects = mature_objects.len(),
+                triggers = trigger_track_ids.len(),
+                path = %image_path,
+                "DatasetCollector saved a frame"
             );
         }
 

--- a/src/lib/detection/detector.rs
+++ b/src/lib/detection/detector.rs
@@ -1,5 +1,7 @@
+use crate::lib::logging;
 use std::fmt;
 use std::io;
+use tracing::info;
 
 use crate::lib::cv::RawFrame;
 use crate::lib::cv::Rect as RectCV;
@@ -70,14 +72,7 @@ impl Detector {
         network_cfg: Option<&str>,
     ) -> Result<Self, DetectorError> {
         let cuda_available = utils::is_cuda_available();
-        println!(
-            "CUDA is {}",
-            if cuda_available {
-                "'available'"
-            } else {
-                "'not available'"
-            }
-        );
+        info!(scope = logging::SCOPE_STARTUP, cuda_available, "CUDA probe");
 
         let dnn_backend = if cuda_available {
             DnnBackend::Cuda
@@ -89,13 +84,16 @@ impl Detector {
         } else {
             DnnTarget::Cpu
         };
-        println!(
-            "Using OpenCV DNN backend with {:?}/{:?}",
-            dnn_backend, dnn_target
+        info!(
+            scope = logging::SCOPE_STARTUP,
+            backend = "opencv",
+            dnn_backend = ?dnn_backend,
+            dnn_target = ?dnn_target,
+            "Inference backend"
         );
 
         let format = utils::detect_model_format(weights)?;
-        println!("Detected model format: {}", format);
+        info!(scope = logging::SCOPE_STARTUP, format = %format, weights, "Detected model format");
 
         let model: Box<dyn ModelTrait> = match format {
             utils::ModelFileFormat::DarknetWeights => {
@@ -106,9 +104,12 @@ impl Detector {
                     ))
                 })?;
                 let cfg_net_size = utils::parse_darknet_cfg_net_size(cfg)?;
-                println!(
-                    "OpenCV Darknet network input size: {}x{} (from {})",
-                    cfg_net_size.0, cfg_net_size.1, cfg
+                info!(
+                    scope = logging::SCOPE_STARTUP,
+                    width = cfg_net_size.0,
+                    height = cfg_net_size.1,
+                    source = cfg,
+                    "Network input size"
                 );
                 Model::darknet(cfg, weights, cfg_net_size, dnn_backend, dnn_target)
                     .map(|m| Box::new(m) as Box<dyn ModelTrait>)
@@ -126,9 +127,12 @@ impl Detector {
                         weights
                     ))
                 })?;
-                println!(
-                    "OpenCV ONNX network input size: {}x{}",
-                    net_size.0, net_size.1
+                info!(
+                    scope = logging::SCOPE_STARTUP,
+                    width = net_size.0,
+                    height = net_size.1,
+                    source = "config",
+                    "Network input size"
                 );
                 Model::opencv(weights, net_size, dnn_backend, dnn_target)
                     .map(|m| Box::new(m) as Box<dyn ModelTrait>)
@@ -156,28 +160,32 @@ impl Detector {
         _network_cfg: Option<&str>,
     ) -> Result<Self, DetectorError> {
         let cuda_available = utils::is_cuda_available();
-        println!(
-            "CUDA is {}",
-            if cuda_available {
-                "'available'"
-            } else {
-                "'not available'"
-            }
-        );
+        info!(scope = logging::SCOPE_STARTUP, cuda_available, "CUDA probe");
 
         #[cfg(feature = "ort-cuda")]
         let backend_name = if cuda_available { "CUDA" } else { "CPU" };
         #[cfg(not(feature = "ort-cuda"))]
         let backend_name = "CPU";
 
-        println!("Using ORT backend ({})", backend_name);
+        info!(
+            scope = logging::SCOPE_STARTUP,
+            backend = "ort",
+            device = backend_name,
+            "Inference backend"
+        );
         let net_size = net_size.ok_or_else(|| {
             DetectorError::Config(format!(
                 "ONNX model '{}' requires net_width/net_height in config.",
                 weights
             ))
         })?;
-        println!("ORT ONNX network input size: {}x{}", net_size.0, net_size.1);
+        info!(
+            scope = logging::SCOPE_STARTUP,
+            width = net_size.0,
+            height = net_size.1,
+            source = "config",
+            "Network input size"
+        );
 
         let net_size_u32 = (net_size.0 as u32, net_size.1 as u32);
 
@@ -191,9 +199,9 @@ impl Detector {
         #[cfg(not(feature = "ort-cuda"))]
         let model_result = Model::ort(weights, net_size_u32);
 
-        model_result
-            .map(Detector::Ort)
-            .map_err(|e| DetectorError::ModelLoad(format!("Can't load ORT model '{}': {:?}", weights, e)))
+        model_result.map(Detector::Ort).map_err(|e| {
+            DetectorError::ModelLoad(format!("Can't load ORT model '{}': {:?}", weights, e))
+        })
     }
 
     #[cfg(all(
@@ -206,14 +214,21 @@ impl Detector {
         _net_size: Option<(i32, i32)>,
         _network_cfg: Option<&str>,
     ) -> Result<Self, DetectorError> {
-        println!("Using TensorRT backend");
+        info!(
+            scope = logging::SCOPE_STARTUP,
+            backend = "tensorrt",
+            "Inference backend"
+        );
         let model = Model::tensorrt(weights).map_err(|e| {
             DetectorError::ModelLoad(format!("Can't load TensorRT model '{}': {:?}", weights, e))
         })?;
         let (w, h) = model.input_size();
-        println!(
-            "TensorRT network input size: {}x{} (from engine)",
-            w, h
+        info!(
+            scope = logging::SCOPE_STARTUP,
+            width = w,
+            height = h,
+            source = "engine",
+            "Network input size"
         );
         Ok(Detector::TensorRT(model))
     }

--- a/src/lib/logging.rs
+++ b/src/lib/logging.rs
@@ -21,8 +21,9 @@ pub const SCOPE_DATASET: &str = "dataset";
 /// Verbosity thresholds: "info" shows error, warn and info lines, "debug" adds debug
 pub const LEVELS: [&str; 2] = ["info", "debug"];
 pub const DEFAULT_LEVEL: &str = "info";
-pub const DEFAULT_MAX_FILE_SIZE_MB: u64 = 50;
-pub const DEFAULT_MAX_FILES: usize = 9;
+/// Small on purpose: the target is an SBC with an SD card
+pub const DEFAULT_MAX_FILE_SIZE_MB: u64 = 10;
+pub const DEFAULT_MAX_FILES: usize = 2;
 
 static RELOAD_HANDLE: OnceLock<reload::Handle<EnvFilter, Registry>> = OnceLock::new();
 

--- a/src/lib/logging.rs
+++ b/src/lib/logging.rs
@@ -4,7 +4,10 @@ use std::sync::OnceLock;
 
 use tracing::{info, warn};
 use tracing_subscriber::{
-    EnvFilter, Registry, fmt, layer::SubscriberExt, reload, util::SubscriberInitExt,
+    EnvFilter, Layer, Registry, fmt,
+    layer::{Layered, SubscriberExt},
+    reload,
+    util::SubscriberInitExt,
 };
 
 pub const LOG_FILE_NAME: &str = "rust-road-traffic.log";
@@ -25,7 +28,13 @@ pub const DEFAULT_LEVEL: &str = "info";
 pub const DEFAULT_MAX_FILE_SIZE_MB: u64 = 10;
 pub const DEFAULT_MAX_FILES: usize = 2;
 
-static RELOAD_HANDLE: OnceLock<reload::Handle<EnvFilter, Registry>> = OnceLock::new();
+/// The file writer is added after the config is read, so it sits behind a
+/// reload layer directly on the registry; the level filter is reloadable too
+type FileLayer = Box<dyn Layer<Registry> + Send + Sync + 'static>;
+type WithFile = Layered<reload::Layer<Option<FileLayer>, Registry>, Registry>;
+
+static FILE_HANDLE: OnceLock<reload::Handle<Option<FileLayer>, Registry>> = OnceLock::new();
+static FILTER_HANDLE: OnceLock<reload::Handle<EnvFilter, WithFile>> = OnceLock::new();
 
 /// Resolved logging configuration, see `VerboseSettings`
 pub struct LogConfig {
@@ -39,61 +48,62 @@ pub struct LogConfig {
     pub max_files: usize,
 }
 
-/// Sets up logging: NDJSON lines to stdout and, when a usable folder is
-/// configured, to `<logs_folder>/rust-road-traffic.log` rotated daily or at
-/// `max_file_size_bytes` with `max_files` old files kept. The level applies to
-/// this crate, dependencies log at warn and above; `RUST_LOG` overrides both.
-/// A folder that cannot be used never stops the app: it logs to stdout only
-/// and says so. The returned guard must live until the end of main: dropping
-/// it flushes the file writer
-#[must_use]
-pub fn init_logger(config: &LogConfig) -> Option<tracing_appender::non_blocking::WorkerGuard> {
+/// Starts logging before anything else happens: NDJSON lines to stdout at
+/// the default level (`RUST_LOG` overrides). The config is not known yet, so
+/// nothing is written to a file until `apply_config` adds it. Safe to call
+/// more than once, only the first call does anything
+pub fn init_logger() {
+    if FILTER_HANDLE.get().is_some() {
+        return;
+    }
+    let (file_layer, file_handle) = reload::Layer::new(None::<FileLayer>);
     let filter = EnvFilter::try_from_default_env()
-        .unwrap_or_else(|_| EnvFilter::new(filter_directive(config.level)));
-    let (filter_layer, handle) = reload::Layer::new(filter);
-    let _ = RELOAD_HANDLE.set(handle);
+        .unwrap_or_else(|_| EnvFilter::new(filter_directive(DEFAULT_LEVEL)));
+    let (filter_layer, filter_handle) = reload::Layer::new(filter);
+    Registry::default()
+        .with(file_layer)
+        .with(filter_layer)
+        .with(json_layer().with_writer(std::io::stdout))
+        .init();
+    let _ = FILE_HANDLE.set(file_handle);
+    let _ = FILTER_HANDLE.set(filter_handle);
+}
+
+/// Applies the `[verbose]` section to the running logger: the level (unless
+/// `RUST_LOG` is set) and, when a usable folder is configured, the file
+/// `<logs_folder>/rust-road-traffic.log` rotated daily or at
+/// `max_file_size_bytes` with `max_files` old files kept. A folder that cannot
+/// be used never stops the app: logging stays on stdout and says so. The
+/// returned guard must live until the end of main: dropping it flushes the
+/// file writer
+#[must_use]
+pub fn apply_config(config: &LogConfig) -> Option<tracing_appender::non_blocking::WorkerGuard> {
+    init_logger();
+    if std::env::var_os("RUST_LOG").is_none() {
+        if let Some(handle) = FILTER_HANDLE.get() {
+            let _ = handle.reload(EnvFilter::new(filter_directive(config.level)));
+        }
+    }
 
     let mut guard = None;
-    let mut file_layer = None;
-    let mut folder_problem = None;
     let mut log_file = None;
+    let mut folder_problem = None;
     if let Some(folder) = &config.logs_folder {
         match open_log_file(folder, config) {
             Ok(appender) => {
                 let (writer, worker_guard) = tracing_appender::non_blocking(appender);
-                guard = Some(worker_guard);
-                log_file = Some(folder.join(LOG_FILE_NAME));
-                file_layer = Some(
-                    fmt::layer()
-                        .json()
-                        .with_target(false)
-                        .with_thread_ids(false)
-                        .with_thread_names(false)
-                        .with_file(false)
-                        .with_line_number(false)
-                        .with_ansi(false)
-                        .with_writer(writer),
-                );
+                let layer: FileLayer = Box::new(json_layer().with_writer(writer));
+                match FILE_HANDLE.get().map(|handle| handle.reload(Some(layer))) {
+                    Some(Ok(())) => {
+                        guard = Some(worker_guard);
+                        log_file = Some(folder.join(LOG_FILE_NAME));
+                    }
+                    _ => folder_problem = Some("can't attach the file writer".to_string()),
+                }
             }
             Err(problem) => folder_problem = Some(problem),
         }
     }
-
-    tracing_subscriber::registry()
-        .with(filter_layer)
-        .with(
-            fmt::layer()
-                .json()
-                .with_target(false)
-                .with_thread_ids(false)
-                .with_thread_names(false)
-                .with_file(false)
-                .with_line_number(false)
-                .with_ansi(false)
-                .with_writer(std::io::stdout),
-        )
-        .with(file_layer)
-        .init();
 
     if let Some(level) = &config.unknown_level {
         warn!(
@@ -104,14 +114,13 @@ pub fn init_logger(config: &LogConfig) -> Option<tracing_appender::non_blocking:
             LEVELS
         );
     }
-    match (&config.logs_folder, folder_problem) {
-        (Some(folder), Some(problem)) => warn!(
+    if let (Some(folder), Some(problem)) = (&config.logs_folder, folder_problem) {
+        warn!(
             scope = SCOPE_STARTUP,
             folder = %folder.display(),
             problem,
             "Can't write log files there, logging to stdout only"
-        ),
-        _ => {}
+        );
     }
     info!(
         scope = SCOPE_STARTUP,
@@ -122,6 +131,21 @@ pub fn init_logger(config: &LogConfig) -> Option<tracing_appender::non_blocking:
         "Logging initialized"
     );
     guard
+}
+
+/// One JSON object per line: timestamp, level and the fields, nothing else
+fn json_layer<S>() -> fmt::Layer<S, fmt::format::JsonFields, fmt::format::Format<fmt::format::Json>>
+where
+    S: tracing::Subscriber + for<'a> tracing_subscriber::registry::LookupSpan<'a>,
+{
+    fmt::layer()
+        .json()
+        .with_target(false)
+        .with_thread_ids(false)
+        .with_thread_names(false)
+        .with_file(false)
+        .with_line_number(false)
+        .with_ansi(false)
 }
 
 /// Makes sure the folder exists, is a directory and the log file in it can be
@@ -156,7 +180,7 @@ pub fn set_log_level(level: &str) -> bool {
     let Some(level) = normalize_level(level) else {
         return false;
     };
-    match RELOAD_HANDLE.get() {
+    match FILTER_HANDLE.get() {
         Some(handle) => handle
             .reload(EnvFilter::new(filter_directive(level)))
             .is_ok(),

--- a/src/lib/logging.rs
+++ b/src/lib/logging.rs
@@ -1,0 +1,224 @@
+//! NDJSON logging to stdout and to a rotated file, configured by `[verbose]`
+use std::path::{Path, PathBuf};
+use std::sync::OnceLock;
+
+use tracing::{info, warn};
+use tracing_subscriber::{
+    EnvFilter, Registry, fmt, layer::SubscriberExt, reload, util::SubscriberInitExt,
+};
+
+pub const LOG_FILE_NAME: &str = "rust-road-traffic.log";
+
+/// `scope` field of every log line: which part of the app is talking
+pub const SCOPE_STARTUP: &str = "startup";
+pub const SCOPE_CAPTURE: &str = "capture";
+pub const SCOPE_PROCESSING: &str = "processing";
+pub const SCOPE_ANALYTICS: &str = "analytics";
+pub const SCOPE_REDIS: &str = "redis";
+pub const SCOPE_REST_API: &str = "rest_api";
+pub const SCOPE_REPORT: &str = "report";
+pub const SCOPE_DATASET: &str = "dataset";
+/// Verbosity thresholds: "info" shows error, warn and info lines, "debug" adds debug
+pub const LEVELS: [&str; 2] = ["info", "debug"];
+pub const DEFAULT_LEVEL: &str = "info";
+pub const DEFAULT_MAX_FILE_SIZE_MB: u64 = 50;
+pub const DEFAULT_MAX_FILES: usize = 9;
+
+static RELOAD_HANDLE: OnceLock<reload::Handle<EnvFilter, Registry>> = OnceLock::new();
+
+/// Resolved logging configuration, see `VerboseSettings`
+pub struct LogConfig {
+    /// One of `LEVELS`
+    pub level: &'static str,
+    /// The level as written in the config when it was not one of `LEVELS`
+    pub unknown_level: Option<String>,
+    /// Folder for the log file, `None` for stdout only
+    pub logs_folder: Option<PathBuf>,
+    pub max_file_size_bytes: u64,
+    pub max_files: usize,
+}
+
+/// Sets up logging: NDJSON lines to stdout and, when a usable folder is
+/// configured, to `<logs_folder>/rust-road-traffic.log` rotated daily or at
+/// `max_file_size_bytes` with `max_files` old files kept. The level applies to
+/// this crate, dependencies log at warn and above; `RUST_LOG` overrides both.
+/// A folder that cannot be used never stops the app: it logs to stdout only
+/// and says so. The returned guard must live until the end of main: dropping
+/// it flushes the file writer
+#[must_use]
+pub fn init_logger(config: &LogConfig) -> Option<tracing_appender::non_blocking::WorkerGuard> {
+    let filter = EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| EnvFilter::new(filter_directive(config.level)));
+    let (filter_layer, handle) = reload::Layer::new(filter);
+    let _ = RELOAD_HANDLE.set(handle);
+
+    let mut guard = None;
+    let mut file_layer = None;
+    let mut folder_problem = None;
+    let mut log_file = None;
+    if let Some(folder) = &config.logs_folder {
+        match open_log_file(folder, config) {
+            Ok(appender) => {
+                let (writer, worker_guard) = tracing_appender::non_blocking(appender);
+                guard = Some(worker_guard);
+                log_file = Some(folder.join(LOG_FILE_NAME));
+                file_layer = Some(
+                    fmt::layer()
+                        .json()
+                        .with_target(false)
+                        .with_thread_ids(false)
+                        .with_thread_names(false)
+                        .with_file(false)
+                        .with_line_number(false)
+                        .with_ansi(false)
+                        .with_writer(writer),
+                );
+            }
+            Err(problem) => folder_problem = Some(problem),
+        }
+    }
+
+    tracing_subscriber::registry()
+        .with(filter_layer)
+        .with(
+            fmt::layer()
+                .json()
+                .with_target(false)
+                .with_thread_ids(false)
+                .with_thread_names(false)
+                .with_file(false)
+                .with_line_number(false)
+                .with_ansi(false)
+                .with_writer(std::io::stdout),
+        )
+        .with(file_layer)
+        .init();
+
+    if let Some(level) = &config.unknown_level {
+        warn!(
+            scope = SCOPE_STARTUP,
+            level,
+            using = config.level,
+            "Unknown verbose level, expected one of {:?}",
+            LEVELS
+        );
+    }
+    match (&config.logs_folder, folder_problem) {
+        (Some(folder), Some(problem)) => warn!(
+            scope = SCOPE_STARTUP,
+            folder = %folder.display(),
+            problem,
+            "Can't write log files there, logging to stdout only"
+        ),
+        _ => {}
+    }
+    info!(
+        scope = SCOPE_STARTUP,
+        level = config.level,
+        file = log_file.as_ref().map(|p| p.display().to_string()),
+        max_file_size_mb = config.max_file_size_bytes / (1024 * 1024),
+        max_files = config.max_files,
+        "Logging initialized"
+    );
+    guard
+}
+
+/// Makes sure the folder exists, is a directory and the log file in it can be
+/// opened for writing, then builds the rotating appender
+fn open_log_file(
+    folder: &Path,
+    config: &LogConfig,
+) -> Result<rolling_file::BasicRollingFileAppender, String> {
+    std::fs::create_dir_all(folder).map_err(|e| format!("can't create folder: {e}"))?;
+    if !folder.is_dir() {
+        return Err("not a directory".to_string());
+    }
+    let file = folder.join(LOG_FILE_NAME);
+    std::fs::OpenOptions::new()
+        .append(true)
+        .create(true)
+        .open(&file)
+        .map_err(|e| format!("can't open {}: {e}", file.display()))?;
+    rolling_file::BasicRollingFileAppender::new(
+        &file,
+        rolling_file::RollingConditionBasic::new()
+            .daily()
+            .max_size(config.max_file_size_bytes),
+        config.max_files,
+    )
+    .map_err(|e| format!("can't set up rotation: {e}"))
+}
+
+/// Changes the verbosity at runtime. `false` when the level is unknown or the
+/// logger is not initialized
+pub fn set_log_level(level: &str) -> bool {
+    let Some(level) = normalize_level(level) else {
+        return false;
+    };
+    match RELOAD_HANDLE.get() {
+        Some(handle) => handle
+            .reload(EnvFilter::new(filter_directive(level)))
+            .is_ok(),
+        None => false,
+    }
+}
+
+/// Canonical spelling of a level, `None` when it is not one of `LEVELS`
+pub fn normalize_level(level: &str) -> Option<&'static str> {
+    let level = level.trim().to_ascii_lowercase();
+    LEVELS.iter().copied().find(|known| *known == level)
+}
+
+fn filter_directive(level: &str) -> String {
+    format!("rust_road_traffic={level},warn")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn config(folder: Option<PathBuf>) -> LogConfig {
+        LogConfig {
+            level: "info",
+            unknown_level: None,
+            logs_folder: folder,
+            max_file_size_bytes: 1024,
+            max_files: 1,
+        }
+    }
+
+    #[test]
+    fn levels_are_normalized() {
+        assert_eq!(normalize_level(" Debug "), Some("debug"));
+        assert_eq!(normalize_level("info"), Some("info"));
+        assert_eq!(normalize_level("error"), None);
+        assert_eq!(normalize_level("trace"), None);
+    }
+
+    #[test]
+    fn set_level_before_init_is_refused() {
+        assert!(!set_log_level("nonsense"));
+    }
+
+    #[test]
+    fn unusable_folders_are_reported_not_fatal() {
+        let file_as_folder =
+            std::env::temp_dir().join(format!("rrt_log_file_{}", std::process::id()));
+        std::fs::write(&file_as_folder, b"x").unwrap();
+        let problem = open_log_file(&file_as_folder, &config(None)).unwrap_err();
+        assert!(!problem.is_empty());
+        let _ = std::fs::remove_file(&file_as_folder);
+
+        let nowhere = PathBuf::from("/dev/null/logs");
+        assert!(open_log_file(&nowhere, &config(None)).is_err());
+    }
+
+    #[test]
+    fn usable_folder_is_created() {
+        let folder = std::env::temp_dir().join(format!("rrt_logs_{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&folder);
+        assert!(open_log_file(&folder, &config(None)).is_ok());
+        assert!(folder.join(LOG_FILE_NAME).is_file());
+        let _ = std::fs::remove_dir_all(&folder);
+    }
+}

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -4,6 +4,7 @@ pub mod data_storage;
 pub mod dataset_collector;
 pub mod detection;
 pub mod draw;
+pub mod logging;
 pub mod mjpeg_streaming;
 pub mod perf_stats;
 pub mod publisher;

--- a/src/lib/perf_stats.rs
+++ b/src/lib/perf_stats.rs
@@ -1,4 +1,6 @@
+use crate::lib::logging;
 use std::time::{Duration, Instant};
+use tracing::info;
 
 /// Performance statistics for detection pipeline.
 /// Accumulates timing data and prints averages every N frames.
@@ -67,15 +69,16 @@ impl PerfStats {
             0.0
         };
 
-        println!(
-            "[PerfStats] Last {} frames avg: inference={:.2}ms, postprocess={:.2}ms, tracking={:.2}ms | total={:.2}ms (~{:.1} FPS) | dropped={}",
-            self.frame_count,
-            avg_inference,
-            avg_postprocess,
-            avg_tracking,
-            avg_total,
-            estimated_fps,
-            self.dropped_total
+        info!(
+            scope = logging::SCOPE_PROCESSING,
+            frames = self.frame_count,
+            inference_ms = format_args!("{:.2}", avg_inference),
+            postprocess_ms = format_args!("{:.2}", avg_postprocess),
+            tracking_ms = format_args!("{:.2}", avg_tracking),
+            total_ms = format_args!("{:.2}", avg_total),
+            fps = format_args!("{:.1}", estimated_fps),
+            dropped = self.dropped_total,
+            "PerfStats"
         );
 
         // Reset

--- a/src/lib/publisher/redis_publisher.rs
+++ b/src/lib/publisher/redis_publisher.rs
@@ -1,5 +1,6 @@
 extern crate redis;
 
+use crate::lib::logging;
 use crate::lib::publisher::RedisMessage;
 use crate::rest_api::zones_stats::{AllZonesStats, VehicleTypeParameters, ZoneStats};
 use crate::{lib::data_storage::ThreadedDataStorage, rest_api::zones_stats::TrafficFlowInfo};
@@ -7,6 +8,7 @@ use redis::{Client, Commands};
 use std::collections::HashMap;
 use std::error::Error;
 use std::sync::Arc;
+use tracing::{error, info};
 
 pub struct RedisConnection {
     pub channel_name: String,
@@ -50,7 +52,7 @@ impl RedisConnection {
         self.channel_name = _channel_name.clone();
     }
     pub fn publish(&self, msg: &dyn RedisMessage) -> Result<(), Box<dyn Error>> {
-        println!("Trying to send data...");
+        info!(scope = logging::SCOPE_REDIS, channel = %self.channel_name, "Publishing to Redis");
         let mut redis_conn = match self.client.get_connection() {
             Ok(_conn) => _conn,
             Err(_err) => {
@@ -59,7 +61,7 @@ impl RedisConnection {
         };
         let msg_string = msg.prepare_string()?;
         let _: usize = redis_conn.publish(self.channel_name.to_owned(), msg_string)?;
-        println!("...Success");
+        info!(scope = logging::SCOPE_REDIS, channel = %self.channel_name, "Published to Redis");
         Ok(())
     }
     pub fn push_statistics(&self) {
@@ -110,8 +112,8 @@ impl RedisConnection {
         drop(zones);
         drop(ds_guard);
         match self.publish(&prepared_message) {
-            Err(_err) => {
-                println!("Errors while sending data to Redis: {}", _err);
+            Err(err) => {
+                error!(scope = logging::SCOPE_REDIS, error = %err, "Can't publish statistics to Redis");
             }
             Ok(_) => {}
         };

--- a/src/lib/tracker/tracker.rs
+++ b/src/lib/tracker/tracker.rs
@@ -1,7 +1,9 @@
+use crate::lib::logging;
 use mot_rs::mot::{BlobBBox, ByteTracker, IoUTracker, SimpleBlob, TrackerError};
 use std::collections::HashMap;
 use std::collections::hash_map::Entry::{Occupied, Vacant};
 use std::fmt;
+use tracing::warn;
 use uuid::Uuid;
 
 use super::object_extra::ObjectExtra;
@@ -362,9 +364,9 @@ pub fn new_tracker_from_type(
             ))
         }
         (_, KalmanFilterType::BBox) => {
-            println!(
-                "Unknown tracker type '{}', falling back to iou_naive",
-                tracker_type
+            warn!(
+                scope = logging::SCOPE_STARTUP,
+                tracker_type, "Unknown tracker type, falling back to iou_naive"
             );
             Box::new(TrackerBBox::<IoUTracker<BlobBBox>>::new_iou(
                 max_no_match,
@@ -372,9 +374,9 @@ pub fn new_tracker_from_type(
             ))
         }
         _ => {
-            println!(
-                "Unknown tracker type '{}', falling back to iou_naive",
-                tracker_type
+            warn!(
+                scope = logging::SCOPE_STARTUP,
+                tracker_type, "Unknown tracker type, falling back to iou_naive"
             );
             Box::new(TrackerSimple::<IoUTracker<SimpleBlob>>::new_iou(
                 max_no_match,

--- a/src/main.rs
+++ b/src/main.rs
@@ -795,33 +795,44 @@ fn run(
 }
 
 fn main() {
+    // Logging comes up first, on stdout only: the config that says where the
+    // file goes is not read yet. `apply_config` below adds the file and the level
+    logging::init_logger();
+    info!(
+        scope = logging::SCOPE_STARTUP,
+        version = env!("CARGO_PKG_VERSION"),
+        "Starting"
+    );
     let args: Vec<String> = env::args().collect();
     let path_to_config = match args.len() {
         2 => &args[1],
         _ => {
-            println!(
-                "Args should contain exactly one string: path to TOML configuration file. Setting to default './data/conf.toml'"
+            warn!(
+                scope = logging::SCOPE_STARTUP,
+                "Expected exactly one argument, the path to the TOML config; using './data/conf.toml'"
             );
             "./data/conf.toml"
         }
     };
     let mut app_settings = AppSettings::new(path_to_config).unwrap_or_else(|e| {
-        eprintln!("Failed to load settings '{}': {}", path_to_config, e);
+        error!(
+            scope = logging::SCOPE_STARTUP,
+            config = path_to_config,
+            error = %e,
+            "Failed to load settings"
+        );
         std::process::exit(1);
     });
-    // Logging is configured by the settings, so everything before this point
-    // can only go to stderr
     let log_config = app_settings
         .verbose
         .clone()
         .unwrap_or_default()
         .to_log_config(path_to_config);
-    let _log_guard = logging::init_logger(&log_config);
+    let _log_guard = logging::apply_config(&log_config);
     info!(
         scope = logging::SCOPE_STARTUP,
         config = path_to_config,
-        version = env!("CARGO_PKG_VERSION"),
-        "Starting"
+        "Settings file read"
     );
     match app_settings.ensure_equipment_id(path_to_config) {
         Ok(Some(id)) => info!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,7 @@ use lib::detection::Detector;
 use lib::detection::KalmanFilterType;
 use lib::detection::process_yolo_detections;
 use lib::draw;
+use lib::logging;
 use lib::perf_stats::{PerfStats, Timer};
 use lib::tracker::{SpatialInfo, TrackerTrait, new_tracker_from_type};
 use lib::zones::Zone;
@@ -39,6 +40,7 @@ use std::thread;
 use std::time::Duration as STDDuration;
 use std::time::Instant;
 use std::time::SystemTime;
+use tracing::{error, info, warn};
 
 fn get_sys_time_in_secs() -> u64 {
     match SystemTime::now().duration_since(SystemTime::UNIX_EPOCH) {
@@ -101,16 +103,13 @@ fn run(
     path_to_config: &str,
     tracker: &mut dyn TrackerTrait,
     detector: &mut Detector,
-    verbose: bool,
 ) -> Result<(), AppError> {
-    println!("Verbose is '{}'", verbose);
-    println!("REST API is '{}'", settings.rest_api.enable);
-    println!("Redis publisher is '{}'", settings.redis_publisher.enable);
-
     let report_mode = settings.is_report_mode();
     if report_mode && !std::path::Path::new(&settings.input.video_src).is_file() {
-        println!(
-            "Report mode is not available for RTSP streams or cameras. Only video files are supported."
+        error!(
+            scope = logging::SCOPE_STARTUP,
+            video_src = %settings.input.video_src,
+            "Report mode is not available for RTSP streams or cameras, only video files are supported"
         );
         return Ok(());
     }
@@ -123,13 +122,18 @@ fn run(
         None => (false, 80),
     };
 
-    println!("MJPEG is '{}' (quality: {})", enable_mjpeg, mjpeg_quality);
-    if report_mode {
-        println!("Report mode is enabled");
-    }
+    info!(
+        scope = logging::SCOPE_STARTUP,
+        rest_api = settings.rest_api.enable,
+        redis_publisher = settings.redis_publisher.enable,
+        mjpeg = enable_mjpeg,
+        mjpeg_quality,
+        report_mode,
+        "Run configuration"
+    );
 
     /* Preprocess spatial data */
-    let data_storage = new_datastorage(settings.equipment_info.id.clone(), verbose);
+    let data_storage = new_datastorage(settings.equipment_info.id.clone());
     let target_classes = HashSet::from_iter(
         settings
             .detection
@@ -159,10 +163,7 @@ fn run(
             match DatasetCollector::new(dc_settings.clone(), &net_classes) {
                 Ok(collector) => Some(collector),
                 Err(err) => {
-                    println!(
-                        "[WARNING] Can't initialize DatasetCollector: {}. Feature disabled.",
-                        err
-                    );
+                    warn!(scope = logging::SCOPE_DATASET, error = %err, "Can't initialize DatasetCollector, feature disabled");
                     None
                 }
             }
@@ -172,9 +173,12 @@ fn run(
 
     // let data_storage_threaded = data_storage.clone();
 
-    println!("Press `Ctrl-C` to stop main programm");
+    info!(scope = logging::SCOPE_STARTUP, "Press Ctrl-C to stop");
     ctrlc::set_handler(move || {
-        println!("Ctrl+C has been pressed! Exit in 2 seconds");
+        info!(
+            scope = logging::SCOPE_STARTUP,
+            "Ctrl-C pressed, exiting in 2 seconds"
+        );
         thread::sleep(STDDuration::from_secs(2));
         process::exit(1);
     })
@@ -235,7 +239,7 @@ fn run(
             ) {
                 Ok(_) => {}
                 Err(err) => {
-                    println!("Can't start API due the error: {:?}", err)
+                    error!(scope = logging::SCOPE_REST_API, error = ?err, "Can't start REST API")
                 }
             }
         });
@@ -254,12 +258,16 @@ fn run(
             .read()
             .expect("DataStorage is poisoned [RWLock]");
         match ds_guard.initialize_zone_grid(width, height) {
-            Ok(_) => println!(
-                "Zone grid initialized: {}x{} with 32px cells",
-                (width / 32.0).ceil() as u32,
-                (height / 32.0).ceil() as u32
+            Ok(_) => info!(
+                scope = logging::SCOPE_STARTUP,
+                columns = (width / 32.0).ceil() as u32,
+                rows = (height / 32.0).ceil() as u32,
+                cell_px = 32,
+                "Zone grid initialized"
             ),
-            Err(e) => println!("Warning: Failed to initialize zone grid: {}", e),
+            Err(e) => {
+                warn!(scope = logging::SCOPE_STARTUP, error = %e, "Failed to initialize zone grid")
+            }
         }
     }
 
@@ -279,11 +287,11 @@ fn run(
             let read_frame = match video_source.read_frame() {
                 Ok(Some(frame)) => frame,
                 Ok(None) => {
-                    println!("End of video stream");
+                    info!(scope = logging::SCOPE_CAPTURE, "End of video stream");
                     break;
                 }
                 Err(e) => {
-                    println!("Can't read next frame: {}", e);
+                    error!(scope = logging::SCOPE_CAPTURE, error = %e, "Can't read next frame");
                     break;
                 }
             };
@@ -316,16 +324,19 @@ fn run(
             processed_frames += 1;
             if report_mode && total_frames > 0.0 && processed_frames % 100 == 0 {
                 let progress = (processed_frames as f32 / total_frames) * 100.0;
-                println!(
-                    "[Report] Progress: {}/{} frames ({:.1}%)",
-                    processed_frames, total_frames as u32, progress
+                info!(
+                    scope = logging::SCOPE_REPORT,
+                    processed = processed_frames,
+                    total = total_frames as u32,
+                    percent = format_args!("{:.1}", progress),
+                    "Report progress"
                 );
             }
 
             if timestamp - period_start_ts >= next_reset as f64 {
-                println!(
-                    "Reset timer due analytics. Current local time is: {}",
-                    timestamp
+                info!(
+                    scope = logging::SCOPE_ANALYTICS,
+                    timestamp, "Analytics period reset"
                 );
                 period_start_ts = timestamp;
                 let mut ds_writer = ds_worker.write().expect("Bad DS");
@@ -346,7 +357,7 @@ fn run(
                         drop(ds_writer)
                     }
                     Err(err) => {
-                        println!("Can't update statistics due the error: {}", err);
+                        error!(scope = logging::SCOPE_ANALYTICS, error = %err, "Can't update statistics");
                     }
                 }
                 if redis_enabled {
@@ -385,13 +396,14 @@ fn run(
     let mut prev_tracked_ts: Option<f64> = None;
     // Frames the capture thread dropped, as of the previous processed frame
     let mut dropped_seen: u64 = 0;
-    println!(
-        "Frame timing: {} source, 1 of every {} frames processed, nominal dt {:.4} s, dt clamped to [{:.4}, {:.2}] s",
-        if live_source { "live" } else { "file" },
-        skip_every_n_frame,
+    info!(
+        scope = logging::SCOPE_CAPTURE,
+        source = if live_source { "live" } else { "file" },
+        process_every_nth_frame = skip_every_n_frame,
         nominal_dt,
-        nominal_dt * 0.25,
-        max_dt
+        dt_min = nominal_dt * 0.25,
+        dt_max = max_dt,
+        "Frame timing"
     );
 
     /* Performance stats (optional) */
@@ -424,17 +436,17 @@ fn run(
 
         /* Inference (preprocessing + forward pass + NMS) */
         let t_inference = Timer::start();
-        let (nms_bboxes, nms_classes_ids, nms_confidences) =
-            match detector.detect_frame(&received.frame, conf_threshold, nms_threshold) {
-                Ok((a, b, c)) => (a, b, c),
-                Err(err) => {
-                    println!(
-                        "Can't process input of neural network due the error {:?}",
-                        err
-                    );
-                    continue;
-                }
-            };
+        let (nms_bboxes, nms_classes_ids, nms_confidences) = match detector.detect_frame(
+            &received.frame,
+            conf_threshold,
+            nms_threshold,
+        ) {
+            Ok((a, b, c)) => (a, b, c),
+            Err(err) => {
+                error!(scope = logging::SCOPE_PROCESSING, error = ?err, "Can't run the detector on the frame");
+                continue;
+            }
+        };
         let inference_time = t_inference.elapsed();
 
         /* Postprocessing: create detection blobs */
@@ -472,7 +484,7 @@ fn run(
         match tracker.match_objects(&mut tmp_detections, relative_time, dt as f32) {
             Ok(_) => {}
             Err(err) => {
-                println!("Can't match objects due the error: {:?}", err);
+                error!(scope = logging::SCOPE_PROCESSING, error = ?err, "Can't match objects");
                 continue;
             }
         };
@@ -530,7 +542,7 @@ fn run(
                 &dc_track_ids,
                 &dc_track_ages,
             ) {
-                println!("[DatasetCollector] Error processing frame: {}", err);
+                warn!(scope = logging::SCOPE_DATASET, error = %err, "DatasetCollector can't process the frame");
             }
         }
 
@@ -716,13 +728,13 @@ fn run(
                 Ok(jpeg_buf) => {
                     match tx_mjpeg.send(jpeg_buf) {
                         Ok(_) => {}
-                        Err(_err) => {
-                            println!("Error on send frame to MJPEG thread: {}", _err)
+                        Err(err) => {
+                            warn!(scope = logging::SCOPE_REST_API, error = %err, "Can't send the frame to the MJPEG thread")
                         }
                     };
                 }
                 Err(e) => {
-                    println!("JPEG encode failed: {}", e);
+                    error!(scope = logging::SCOPE_REST_API, error = %e, "JPEG encode failed");
                 }
             }
         } else {
@@ -734,7 +746,10 @@ fn run(
     }
 
     if report_mode {
-        println!("Video processing complete. Generating report...");
+        info!(
+            scope = logging::SCOPE_REPORT,
+            "Video processing complete, generating report"
+        );
         let report_settings = settings.report.as_ref().unwrap();
         {
             let mut ds_writer = data_storage
@@ -744,7 +759,7 @@ fn run(
             match ds_writer.update_statistics() {
                 Ok(_) => {}
                 Err(err) => {
-                    println!("Can't compute final statistics due the error: {}", err);
+                    error!(scope = logging::SCOPE_REPORT, error = %err, "Can't compute final statistics");
                 }
             }
         }
@@ -759,12 +774,19 @@ fn run(
                     &report_settings.output_path,
                     frame,
                 ) {
-                    Ok(zip_path) => println!("Report saved to: {}", zip_path),
-                    Err(err) => println!("Can't generate report due the error: {}", err),
+                    Ok(zip_path) => {
+                        info!(scope = logging::SCOPE_REPORT, path = %zip_path, "Report saved")
+                    }
+                    Err(err) => {
+                        error!(scope = logging::SCOPE_REPORT, error = %err, "Can't generate report")
+                    }
                 }
             }
             None => {
-                println!("Can't generate report: no frames were captured from video");
+                error!(
+                    scope = logging::SCOPE_REPORT,
+                    "Can't generate report: no frames were captured from video"
+                );
             }
         }
     }
@@ -787,21 +809,44 @@ fn main() {
         eprintln!("Failed to load settings '{}': {}", path_to_config, e);
         std::process::exit(1);
     });
+    // Logging is configured by the settings, so everything before this point
+    // can only go to stderr
+    let log_config = app_settings
+        .verbose
+        .clone()
+        .unwrap_or_default()
+        .to_log_config(path_to_config);
+    let _log_guard = logging::init_logger(&log_config);
+    info!(
+        scope = logging::SCOPE_STARTUP,
+        config = path_to_config,
+        version = env!("CARGO_PKG_VERSION"),
+        "Starting"
+    );
     match app_settings.ensure_equipment_id(path_to_config) {
-        Ok(Some(id)) => println!(
-            "Equipment id was blank, generated '{}' and saved it to '{}'",
-            id, path_to_config
+        Ok(Some(id)) => info!(
+            scope = logging::SCOPE_STARTUP,
+            equipment_id = %id,
+            config = path_to_config,
+            "Equipment id was blank, generated one and saved it"
         ),
         Ok(None) => {}
         Err(e) => {
-            eprintln!(
-                "Can't save generated equipment id to '{}': {}",
-                path_to_config, e
-            );
+            error!(scope = logging::SCOPE_STARTUP, error = %e, config = path_to_config, "Can't save the generated equipment id");
             std::process::exit(1);
         }
     }
-    println!("Settings are:\n\t{}", app_settings);
+    info!(
+        scope = logging::SCOPE_STARTUP,
+        equipment_id = %app_settings.equipment_info.id,
+        video_src = %app_settings.input.video_src,
+        network_weights = %app_settings.detection.network_weights,
+        tracker = app_settings.tracking.typ.as_deref().unwrap_or("iou_naive"),
+        kalman_filter = app_settings.tracking.kalman_filter.as_deref().unwrap_or("centroid"),
+        reset_data_milliseconds = app_settings.worker.reset_data_milliseconds,
+        rest_api = format_args!("{}:{}", app_settings.rest_api.host, app_settings.rest_api.back_end_port),
+        "Settings loaded"
+    );
 
     let kalman_filter: KalmanFilterType = app_settings
         .tracking
@@ -817,7 +862,7 @@ fn main() {
         app_settings.tracking.max_lost_seconds,
         app_settings.tracking.iou_threshold,
     );
-    println!("Tracker is:\n\t{}", tracker);
+    info!(scope = logging::SCOPE_STARTUP, tracker = %tracker, "Tracker initialized");
 
     let net_size = match (
         app_settings.detection.net_width,
@@ -832,25 +877,14 @@ fn main() {
         app_settings.detection.network_cfg.as_deref(),
     )
     .unwrap_or_else(|e| {
-        eprintln!("Failed to create detector: {}", e);
+        error!(scope = logging::SCOPE_STARTUP, error = %e, "Failed to create detector");
         std::process::exit(1);
     });
 
-    let verbose = match &app_settings.debug {
-        Some(x) => x.enable,
-        None => false,
-    };
-
-    match run(
-        &app_settings,
-        path_to_config,
-        &mut *tracker,
-        &mut detector,
-        verbose,
-    ) {
+    match run(&app_settings, path_to_config, &mut *tracker, &mut detector) {
         Ok(_) => {}
-        Err(_err) => {
-            println!("Error in main thread: {}", _err);
+        Err(err) => {
+            error!(scope = logging::SCOPE_PROCESSING, error = %err, "Error in main thread");
         }
     };
 }

--- a/src/rest_api/rest_api.rs
+++ b/src/rest_api/rest_api.rs
@@ -1,6 +1,8 @@
+use crate::lib::logging;
 use actix_cors::Cors;
 use actix_web::{App, HttpServer, http, web};
 use std::sync::{Arc, RwLock};
+use tracing::info;
 
 use crate::lib::data_storage::ThreadedDataStorage;
 use crate::lib::mjpeg_streaming::Broadcaster;
@@ -26,10 +28,7 @@ pub async fn start_rest_api(
     settings_filename: &str,
 ) -> std::io::Result<()> {
     let bind_address = format!("{}:{}", server_host, server_port);
-    println!(
-        "REST API is starting on host:port {}:{}",
-        server_host, server_port
-    );
+    info!(scope = logging::SCOPE_REST_API, host = %server_host, port = server_port, "REST API starting");
     let storage = APIStorage {
         data_storage: data_storage,
         app_settings: app_settings,

--- a/src/rest_api/toml_mutations.rs
+++ b/src/rest_api/toml_mutations.rs
@@ -1,8 +1,10 @@
+use crate::lib::logging;
 use crate::rest_api::APIStorage;
 use crate::settings::RoadLanesSettings;
 use crate::settings::VirtualLineSettings;
 use actix_web::{Error, HttpResponse, web};
 use serde::Serialize;
+use tracing::info;
 use utoipa::ToSchema;
 
 /// Error response
@@ -31,7 +33,7 @@ pub struct UpdateTOMLResponse<'a> {
     )
 )]
 pub async fn save_toml(data: web::Data<APIStorage>) -> Result<HttpResponse, Error> {
-    println!("Saving TOML configuration");
+    info!(scope = logging::SCOPE_REST_API, file = %data.settings_filename, "Saving TOML configuration");
     let ds_guard = data
         .data_storage
         .read()

--- a/src/rest_api/zones_mutations.rs
+++ b/src/rest_api/zones_mutations.rs
@@ -1,8 +1,10 @@
+use crate::lib::logging;
 use crate::lib::zones::{VirtualLine, VirtualLineDirection, Zone};
 use crate::rest_api::APIStorage;
 use actix_web::{Error, HttpResponse, http::StatusCode, web};
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
+use tracing::info;
 use utoipa::ToSchema;
 
 /// Error response
@@ -114,7 +116,11 @@ pub async fn update_zone(
 
     match _update_zone.lane_number {
         Some(val) => {
-            println!("lane_number: {}", val);
+            info!(
+                scope = logging::SCOPE_REST_API,
+                lane_number = val,
+                "Zone lane number updated"
+            );
             let mut zone = zone_guarded.lock().expect("Zone is poisoned [Mutex]");
             zone.set_road_lane_num(val);
             drop(zone)

--- a/src/settings/settings.rs
+++ b/src/settings/settings.rs
@@ -43,7 +43,7 @@ impl From<toml::de::Error> for SettingsError {
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct AppSettings {
     pub input: InputSettings,
-    pub debug: Option<DebugSettings>,
+    pub verbose: Option<VerboseSettings>,
     pub detection: DetectionSettings,
     pub tracking: TrackingSettings,
     /// Identifies the installation point in everything the app publishes.
@@ -67,9 +67,69 @@ pub struct InputSettings {
     pub process_every_nth_frame: Option<u32>,
 }
 
-#[derive(Serialize, Deserialize, Debug, Clone)]
-pub struct DebugSettings {
-    pub enable: bool,
+/// `[verbose]`: logging is always on, this only sets how much and where.
+/// The whole section and every key are optional
+#[derive(Serialize, Deserialize, Debug, Clone, Default)]
+pub struct VerboseSettings {
+    /// "info" (default) or "debug". `RUST_LOG` overrides it
+    pub level: Option<String>,
+    /// Folder for the NDJSON log file, default "./logs" next to the config file.
+    /// Empty string = stdout only. Logs always go to stdout as well
+    pub logs_folder: Option<String>,
+    /// The file rotates daily or at this size, default 10
+    pub max_file_size_mb: Option<u64>,
+    /// Old files kept after rotation, default 2
+    pub max_files: Option<usize>,
+}
+
+impl VerboseSettings {
+    /// Turns the section into what the logger needs, with nonsense replaced by
+    /// defaults: a relative folder is taken from the config file's folder, not
+    /// from the working directory, so a service started from anywhere logs to
+    /// the same place
+    pub fn to_log_config(&self, config_path: &str) -> logging::LogConfig {
+        let (level, unknown_level) = match self.level.as_deref() {
+            None => (logging::DEFAULT_LEVEL, None),
+            Some(level) => match logging::normalize_level(level) {
+                Some(level) => (level, None),
+                None => (logging::DEFAULT_LEVEL, Some(level.to_string())),
+            },
+        };
+        let folder = self
+            .logs_folder
+            .as_deref()
+            .map(str::trim)
+            .unwrap_or("./logs");
+        let logs_folder = if folder.is_empty() {
+            None
+        } else {
+            let folder = std::path::Path::new(folder);
+            let base = std::path::Path::new(config_path)
+                .parent()
+                .filter(|parent| !parent.as_os_str().is_empty())
+                .unwrap_or_else(|| std::path::Path::new("."));
+            Some(if folder.is_absolute() {
+                folder.to_path_buf()
+            } else {
+                base.join(folder)
+            })
+        };
+        let max_file_size_mb = match self.max_file_size_mb {
+            Some(mb) if mb > 0 => mb,
+            _ => logging::DEFAULT_MAX_FILE_SIZE_MB,
+        };
+        let max_files = match self.max_files {
+            Some(n) if n > 0 => n,
+            _ => logging::DEFAULT_MAX_FILES,
+        };
+        logging::LogConfig {
+            level,
+            unknown_level,
+            logs_folder,
+            max_file_size_bytes: max_file_size_mb * 1024 * 1024,
+            max_files,
+        }
+    }
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -221,6 +281,7 @@ pub struct ReportSettings {
 }
 
 use crate::lib::cv::Scalar;
+use crate::lib::logging;
 use crate::lib::spatial::Point2f;
 use crate::lib::spatial::epsg::lonlat_to_meters;
 use crate::lib::zones::Zone;
@@ -556,10 +617,6 @@ impl AppSettings {
             }
         }
 
-        if app_settings.debug.is_none() {
-            app_settings.debug = Some(DebugSettings { enable: false });
-        }
-
         Ok(app_settings)
     }
     /// Writes the settings back to `filename` keeping the file's comments, key
@@ -614,7 +671,7 @@ impl AppSettings {
     pub fn get_copy_no_roads(&self) -> AppSettings {
         AppSettings {
             input: self.input.clone(),
-            debug: self.debug.clone(),
+            verbose: self.verbose.clone(),
             detection: self.detection.clone(),
             tracking: self.tracking.clone(),
             equipment_info: self.equipment_info.clone(),
@@ -882,5 +939,45 @@ mod tests {
             AppSettings::new(&file.0).unwrap().equipment_info.id,
             generated
         );
+    }
+
+    #[test]
+    fn verbose_defaults_and_nonsense() {
+        let cfg = VerboseSettings::default().to_log_config("/etc/rrt/conf.toml");
+        assert_eq!(cfg.level, "info");
+        assert_eq!(
+            cfg.logs_folder.as_deref(),
+            Some(std::path::Path::new("/etc/rrt/./logs"))
+        );
+        assert_eq!(cfg.max_file_size_bytes, 10 * 1024 * 1024);
+        assert_eq!(cfg.max_files, 2);
+
+        let cfg = VerboseSettings {
+            level: Some("Verbose".to_string()),
+            logs_folder: Some("   ".to_string()),
+            max_file_size_mb: Some(0),
+            max_files: Some(0),
+        }
+        .to_log_config("conf.toml");
+        assert_eq!(cfg.level, "info");
+        assert_eq!(cfg.unknown_level.as_deref(), Some("Verbose"));
+        assert_eq!(cfg.logs_folder, None);
+        assert_eq!(cfg.max_file_size_bytes, 10 * 1024 * 1024);
+        assert_eq!(cfg.max_files, 2);
+
+        let cfg = VerboseSettings {
+            level: Some("DEBUG".to_string()),
+            logs_folder: Some("/var/log/rrt".to_string()),
+            max_file_size_mb: Some(5),
+            max_files: Some(2),
+        }
+        .to_log_config("conf.toml");
+        assert_eq!(cfg.level, "debug");
+        assert_eq!(
+            cfg.logs_folder.as_deref(),
+            Some(std::path::Path::new("/var/log/rrt"))
+        );
+        assert_eq!(cfg.max_file_size_bytes, 5 * 1024 * 1024);
+        assert_eq!(cfg.max_files, 2);
     }
 }

--- a/src/video_capture/capture.rs
+++ b/src/video_capture/capture.rs
@@ -1,5 +1,7 @@
+use crate::lib::logging;
 use std::io::Read;
 use std::process::{Child, Command, Stdio};
+use tracing::info;
 
 use crate::lib::cv::RawFrame;
 
@@ -73,9 +75,13 @@ impl VideoSource {
         let kind = detect_source_kind(video_src);
         let info = probe_video(video_src, &kind)?;
 
-        println!(
-            "Video probe: {{Width: {}px | Height: {}px | FPS: {} | Total frames: {}}}",
-            info.width, info.height, info.fps, info.total_frames
+        info!(
+            scope = logging::SCOPE_CAPTURE,
+            width = info.width,
+            height = info.height,
+            fps = info.fps,
+            total_frames = info.total_frames,
+            "Video probe"
         );
 
         let child = spawn_subprocess(video_src, &kind, &info)?;


### PR DESCRIPTION
Replaces tons of `println!` with `tracing`: NDJSON lines on stdout and in a rotated file. Every line has `level` (ERROR/WARN/INFO), `scope` (startup, capture, processing, analytics, redis, rest_api, report, dataset) and structured fields instead of formatted text. The OD matrix is no longer an ASCII table: one `OD matrix updated` line plus an `OD flow` line per non-zero pair.

`[debug]` is gone; the optional `[verbose]` section sets `level` (info/debug threshold, `RUST_LOG` overrides), `logs_folder` (relative to the config file, empty = stdout only), `max_file_size_mb` and `max_files` (defaults 10 MB / 2 files - the target is an SBC with an SD card). Nonsense falls back to defaults with a WARN; an unwritable folder never stops the app, it logs to stdout only.
