### PR TITLE
HTTP API to restart the application in place

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2663,6 +2663,7 @@ dependencies = [
  "mot-rs",
  "nalgebra",
  "ndarray",
+ "nix",
  "od_opencv",
  "opencv",
  "png",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,11 @@ turbojpeg = { version = "1.4", default-features = false, features = ["pkg-config
 # PNG encoding for report snapshots
 png = "0.18.1"
 
+# Sending a specific signal to the capture subprocess, see `end_child`.
+# Already in the tree: ctrlc pulls the same crate
+[target.'cfg(unix)'.dependencies]
+nix = { version = "0.30", features = ["signal"] }
+
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }
 

--- a/README.md
+++ b/README.md
@@ -335,7 +335,22 @@ Locally you can access Swagger UI documentation via http://localhost:42001/api/d
         reset_data_milliseconds = 30000
     ```
 
-13. Logging
+13. Restarting
+
+    Some settings are only read at startup: the video source, the tracker, Redis publisher and the statistics refresher period. API `POST /api/mutations/restart` restarts the application to pick them up, without knowing what supervises it:
+
+    ```shell
+    curl -X POST http://localhost:42001/api/mutations/restart
+    # {"message":"restarting"}
+    ```
+
+    The process replaces its own image, keeping the same PID, so systemd sees no exit, a container whose entrypoint is this binary keeps running, and a plain terminal run comes back as well. Nothing is saved first: unsaved zones stay unsaved (save them with `/api/mutations/save_toml`), and a config edited over SSH is picked up exactly as written. The reply is sent before the restart happens, so wait for `/api/ping` to answer again.
+
+    The capture subprocess is shut down properly on the way out, and on `Ctrl-C` as well: it is sent `SIGINT`, which `gst-launch-1.0` answers by taking the pipeline down to NULL, and only killed if it does not go within two seconds. That matters on a Jetson CSI camera, where only the orderly teardown closes the Argus session — a session left open keeps the sensor busy for the next start.
+
+    Under systemd, add `KillMode=mixed` to the unit so that stopping the service signals this process alone and lets it shut its pipeline down; with the default `control-group` systemd signals `gst-launch-1.0` directly, which kills it with the pipeline still up.
+
+14. Logging
 
     Logs are NDJSON (one JSON object per line) on stdout and, by default, in `./logs/rust-road-traffic.log` next to the config file. Every line carries `level` (`INFO`, `WARN`, `ERROR`), `scope` (`startup`, `capture`, `processing`, `analytics`, `redis`, `rest_api`, `report`, `dataset`) and the message with its fields:
 

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -9,6 +9,7 @@ pub mod mjpeg_streaming;
 pub mod perf_stats;
 pub mod publisher;
 pub mod report;
+pub mod restart;
 pub mod spatial;
 pub mod tracker;
 pub mod utils;

--- a/src/lib/restart.rs
+++ b/src/lib/restart.rs
@@ -1,0 +1,76 @@
+//! Restarting the app from the inside, without knowing what supervises it
+use std::io;
+use std::path::PathBuf;
+use std::process::Command;
+
+use tracing::{error, info};
+
+use crate::lib::logging;
+use crate::video_capture::kill_capture_subprocesses;
+
+/// The executable and the arguments a restart runs, i.e. exactly what this
+/// process was started with
+pub fn restart_command() -> io::Result<(PathBuf, Vec<String>)> {
+    Ok((std::env::current_exe()?, std::env::args().skip(1).collect()))
+}
+
+/// Replaces the running process with a fresh copy of itself: same executable,
+/// same arguments, same working directory and environment.
+///
+/// The point of replacing rather than exiting is that the app does not have to
+/// know what started it. The process id stays the same, so systemd sees no
+/// exit and restarts nothing, a container whose entrypoint is this binary keeps
+/// running with its PID 1 in place, and a plain terminal run comes back too.
+/// Nothing is saved on the way out: writing the config is a separate request.
+///
+/// Returns only on failure, in which case the process keeps running as it was
+pub fn restart_process() -> io::Error {
+    let (exe, args) = match restart_command() {
+        Ok(command) => command,
+        Err(e) => return e,
+    };
+    info!(
+        scope = logging::SCOPE_STARTUP,
+        executable = %exe.display(),
+        args = ?args,
+        "Restarting"
+    );
+    // Nothing below runs a destructor, so the capture subprocess has to go first
+    kill_capture_subprocesses();
+    let error = replace_process(&exe, &args);
+    error!(
+        scope = logging::SCOPE_STARTUP,
+        executable = %exe.display(),
+        error = %error,
+        "Can't restart, keeping the process as it is"
+    );
+    error
+}
+
+#[cfg(unix)]
+fn replace_process(exe: &PathBuf, args: &[String]) -> io::Error {
+    use std::os::unix::process::CommandExt;
+    // exec() only ever returns an error: on success this image is gone
+    Command::new(exe).args(args).exec()
+}
+
+#[cfg(not(unix))]
+fn replace_process(_exe: &PathBuf, _args: &[String]) -> io::Error {
+    io::Error::new(
+        io::ErrorKind::Unsupported,
+        "restarting in place is only implemented for unix",
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn restart_command_is_this_process() {
+        let (exe, args) = restart_command().unwrap();
+        assert!(exe.is_file(), "{}", exe.display());
+        // The test binary gets its own arguments, they just must not include argv[0]
+        assert!(!args.iter().any(|arg| arg == exe.to_string_lossy().as_ref()));
+    }
+}

--- a/src/lib/restart.rs
+++ b/src/lib/restart.rs
@@ -2,11 +2,31 @@
 use std::io;
 use std::path::PathBuf;
 use std::process::Command;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::thread;
+use std::time::Duration;
 
 use tracing::{error, info};
 
 use crate::lib::logging;
 use crate::video_capture::kill_capture_subprocesses;
+
+/// Set while a restart is under way.
+///
+/// Taking the capture subprocess down makes the capture thread see the end of
+/// its stream, which is how the app normally finishes: without this the
+/// process would run to completion and exit in the moment between the two,
+/// and there would be nothing left to replace
+static RESTARTING: AtomicBool = AtomicBool::new(false);
+
+/// Blocks while a restart is under way, that is until `exec` replaces this
+/// process image or the restart gives up. Call it wherever the app would
+/// otherwise return from `main`
+pub fn wait_while_restarting() {
+    while RESTARTING.load(Ordering::SeqCst) {
+        thread::sleep(Duration::from_millis(20));
+    }
+}
 
 /// The executable and the arguments a restart runs, i.e. exactly what this
 /// process was started with
@@ -29,6 +49,7 @@ pub fn restart_process() -> io::Error {
         Ok(command) => command,
         Err(e) => return e,
     };
+    RESTARTING.store(true, Ordering::SeqCst);
     info!(
         scope = logging::SCOPE_STARTUP,
         executable = %exe.display(),
@@ -38,6 +59,7 @@ pub fn restart_process() -> io::Error {
     // Nothing below runs a destructor, so the capture subprocess has to go first
     kill_capture_subprocesses();
     let error = replace_process(&exe, &args);
+    RESTARTING.store(false, Ordering::SeqCst);
     error!(
         scope = logging::SCOPE_STARTUP,
         executable = %exe.display(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,7 +24,7 @@ mod settings;
 use settings::AppSettings;
 
 mod video_capture;
-use video_capture::{ThreadedFrame, VideoSource, frame_channel};
+use video_capture::{ThreadedFrame, VideoSource, frame_channel, kill_capture_subprocesses};
 
 use lib::publisher::RedisConnection;
 
@@ -37,7 +37,6 @@ use std::iter::FromIterator;
 use std::process;
 use std::sync::mpsc;
 use std::thread;
-use std::time::Duration as STDDuration;
 use std::time::Instant;
 use std::time::SystemTime;
 use tracing::{error, info, warn};
@@ -175,11 +174,10 @@ fn run(
 
     info!(scope = logging::SCOPE_STARTUP, "Press Ctrl-C to stop");
     ctrlc::set_handler(move || {
-        info!(
-            scope = logging::SCOPE_STARTUP,
-            "Ctrl-C pressed, exiting in 2 seconds"
-        );
-        thread::sleep(STDDuration::from_secs(2));
+        info!(scope = logging::SCOPE_STARTUP, "Interrupted, shutting down");
+        // Exiting runs no destructors, so the capture subprocess is taken down
+        // here; this waits for it, which is what the blind sleep used to cover
+        kill_capture_subprocesses();
         process::exit(1);
     })
     .expect("Error setting `Ctrl-C` handler");
@@ -898,4 +896,7 @@ fn main() {
             error!(scope = logging::SCOPE_PROCESSING, error = %err, "Error in main thread");
         }
     };
+    // A restart takes the capture subprocess down, which ends the run above:
+    // stay alive until this process image is replaced
+    lib::restart::wait_while_restarting();
 }

--- a/src/rest_api/mod.rs
+++ b/src/rest_api/mod.rs
@@ -1,6 +1,7 @@
 mod mjpeg_client;
 mod mjpeg_page;
 mod rest_api;
+mod restart;
 mod services;
 mod toml_mutations;
 mod zones_list;

--- a/src/rest_api/restart.rs
+++ b/src/rest_api/restart.rs
@@ -1,0 +1,49 @@
+use actix_web::{Error, HttpResponse};
+use serde::Serialize;
+use std::thread;
+use std::time::Duration;
+use tracing::info;
+use utoipa::ToSchema;
+
+use crate::lib::logging;
+use crate::lib::restart::restart_process;
+
+/// Time given to the reply and the buffered log lines to leave the process
+/// before its image is replaced
+const GRACE: Duration = Duration::from_millis(300);
+
+/// Response for the restart request
+#[derive(Debug, Serialize, ToSchema)]
+pub struct RestartResponse<'a> {
+    /// Message
+    #[schema(example = "restarting")]
+    pub message: &'a str,
+}
+
+#[utoipa::path(
+    post,
+    tag = "Application",
+    path = "/api/mutations/restart",
+    responses(
+        (status = 200, description = "The application is restarting", body = RestartResponse)
+    )
+)]
+/// Restarts the application with the configuration file as it is on disk.
+///
+/// Nothing is saved first: unsaved zones stay unsaved and a config edited over
+/// SSH is picked up as written. The reply is sent before the restart happens,
+/// so the caller should wait for `/api/ping` to answer again
+pub async fn restart() -> Result<HttpResponse, Error> {
+    info!(
+        scope = logging::SCOPE_REST_API,
+        grace_ms = GRACE.as_millis() as u64,
+        "Restart requested"
+    );
+    thread::spawn(|| {
+        thread::sleep(GRACE);
+        restart_process();
+    });
+    Ok(HttpResponse::Ok().json(RestartResponse {
+        message: "restarting",
+    }))
+}

--- a/src/rest_api/services.rs
+++ b/src/rest_api/services.rs
@@ -3,7 +3,7 @@ use actix_web_static_files::ResourceFiles;
 include!(concat!(env!("OUT_DIR"), "/generated.rs"));
 
 use crate::rest_api::{
-    mjpeg_client, mjpeg_page, toml_mutations, zones_list, zones_mutations, zones_stats,
+    mjpeg_client, mjpeg_page, restart, toml_mutations, zones_list, zones_mutations, zones_stats,
 };
 
 async fn say_ping() -> impl Responder {
@@ -53,7 +53,8 @@ pub fn init_routes(enable_mjpeg: bool) -> impl Fn(&mut web::ServiceConfig) {
                             web::post().to(zones_mutations::delete_zone),
                         )
                         .route("/replace_all", web::post().to(zones_mutations::replace_all))
-                        .route("/save_toml", web::get().to(toml_mutations::save_toml)),
+                        .route("/save_toml", web::get().to(toml_mutations::save_toml))
+                        .route("/restart", web::post().to(restart::restart)),
                 ),
         );
         cfg.service(ResourceFiles::new("/", generated));
@@ -75,11 +76,13 @@ use utoipa_rapidoc::RapiDoc;
         zones_mutations::delete_zone,
         zones_mutations::replace_all,
         toml_mutations::save_toml,
+        restart::restart,
     ),
     tags(
         (name = "Zones", description = "Main information about detection zones"),
         (name = "Statistics", description = "Aggregated and real-time statistics in the detections zones"),
         (name = "Zones mutations", description = "A way to mutate information about detection zones"),
+        (name = "Application", description = "Managing the running application"),
     ),
     components(
         // We need to import all possible schemas since `utopia` can't discover recursive schemas (yet?)
@@ -106,6 +109,7 @@ use utoipa_rapidoc::RapiDoc;
             crate::rest_api::zones_mutations::ZonesOverwriteAllResponse,
             crate::rest_api::zones_mutations::ErrorResponse,
             crate::rest_api::toml_mutations::UpdateTOMLResponse,
+            crate::rest_api::restart::RestartResponse,
             crate::rest_api::toml_mutations::ErrorResponse,
         ),
     )

--- a/src/video_capture/capture.rs
+++ b/src/video_capture/capture.rs
@@ -1,6 +1,9 @@
 use crate::lib::logging;
 use std::io::Read;
-use std::process::{Child, Command, Stdio};
+use std::process::{Child, ChildStdout, Command, Stdio};
+use std::sync::Mutex;
+use std::thread;
+use std::time::{Duration, Instant};
 use tracing::info;
 
 use crate::lib::cv::RawFrame;
@@ -49,12 +52,101 @@ enum SourceKind {
     GStreamer,
 }
 
+/// The capture subprocesses started by this process.
+///
+/// A restart replaces the process image without running a single destructor,
+/// so an ffmpeg or gst-launch child would outlive it, still holding the camera
+/// and blocked writing into a pipe nobody reads. Keeping the `Child` here
+/// rather than in the `VideoSource` alone means any thread can end it properly:
+/// killing it from the outside would leave a zombie, since only the parent can
+/// reap a child, and after `exec` nobody is left to do it
+static CHILDREN: Mutex<Vec<Child>> = Mutex::new(Vec::new());
+
+/// Kills and reaps every capture subprocess. Call it before anything that ends
+/// the process without unwinding
+pub fn kill_capture_subprocesses() {
+    let children = match CHILDREN.lock() {
+        Ok(mut registry) => std::mem::take(&mut *registry),
+        Err(poisoned) => std::mem::take(&mut *poisoned.into_inner()),
+    };
+    for mut child in children {
+        end_child(&mut child);
+    }
+}
+
+fn register_child(child: Child) {
+    let mut registry = CHILDREN
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    registry.push(child);
+}
+
+/// Ends the subprocess with this pid, if it is still registered
+fn end_child_by_pid(pid: u32) {
+    let mut registry = CHILDREN
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    if let Some(index) = registry.iter().position(|child| child.id() == pid) {
+        let mut child = registry.remove(index);
+        drop(registry);
+        end_child(&mut child);
+    }
+}
+
+/// How long a capture subprocess is given to shut itself down after the
+/// interrupt, before it is killed outright
+const GRACEFUL_EXIT: Duration = Duration::from_secs(2);
+const EXIT_POLL: Duration = Duration::from_millis(20);
+
+/// Interrupt, wait a little, kill if that was not enough, and always reap.
+///
+/// The interrupt is SIGINT rather than SIGTERM because that is what the two
+/// programs we spawn actually listen to: `gst-launch-1.0` answers SIGINT by
+/// taking the pipeline down to NULL and exits 0, while SIGTERM kills it
+/// outright (exit 143) with the pipeline still up; ffmpeg treats both the
+/// same. On a Jetson CSI camera the difference is the whole point: only the
+/// orderly teardown closes the Argus session, and a session left open keeps
+/// the sensor busy for whoever starts next.
+///
+/// Reaping matters just as much: a killed child that is never waited for stays
+/// a zombie, and after a restart there is no one left to collect it
+fn end_child(child: &mut Child) {
+    if interrupt(child.id()) {
+        let deadline = Instant::now() + GRACEFUL_EXIT;
+        while Instant::now() < deadline {
+            match child.try_wait() {
+                Ok(Some(_)) => return,
+                Ok(None) => thread::sleep(EXIT_POLL),
+                Err(_) => break,
+            }
+        }
+    }
+    let _ = child.kill();
+    let _ = child.wait();
+}
+
+#[cfg(unix)]
+fn interrupt(pid: u32) -> bool {
+    nix::sys::signal::kill(
+        nix::unistd::Pid::from_raw(pid as i32),
+        nix::sys::signal::Signal::SIGINT,
+    )
+    .is_ok()
+}
+
+#[cfg(not(unix))]
+fn interrupt(_pid: u32) -> bool {
+    false
+}
+
 /// Video capture via ffmpeg or gst-launch-1.0 subprocess.
 ///
 /// Supports file, RTSP, V4L2 camera, and GStreamer pipeline sources.
 /// Output pixel format: BGR24, row-major, no padding.
 pub struct VideoSource {
-    child: Child,
+    /// The subprocess itself lives in `CHILDREN`; this is its output pipe
+    stdout: ChildStdout,
+    child_pid: u32,
     width: u32,
     height: u32,
     fps: f32,
@@ -84,12 +176,19 @@ impl VideoSource {
             "Video probe"
         );
 
-        let child = spawn_subprocess(video_src, &kind, &info)?;
+        let mut child = spawn_subprocess(video_src, &kind, &info)?;
+        let child_pid = child.id();
+        let stdout = child
+            .stdout
+            .take()
+            .ok_or_else(|| CaptureError::ProcessError("subprocess stdout not available".into()))?;
+        register_child(child);
         let frame_size = info.width as usize * info.height as usize * 3;
         let live = is_live_source(video_src, &kind);
 
         Ok(Self {
-            child,
+            stdout,
+            child_pid,
             width: info.width,
             height: info.height,
             fps: info.fps,
@@ -102,14 +201,9 @@ impl VideoSource {
 
     /// Read the next frame. Returns `Ok(None)` on EOF.
     pub fn read_frame(&mut self) -> Result<Option<RawFrame>, CaptureError> {
-        let stdout =
-            self.child.stdout.as_mut().ok_or_else(|| {
-                CaptureError::ProcessError("subprocess stdout not available".into())
-            })?;
-
         let mut total_read = 0;
         while total_read < self.frame_size {
-            match stdout.read(&mut self.buf[total_read..self.frame_size]) {
+            match self.stdout.read(&mut self.buf[total_read..self.frame_size]) {
                 Ok(0) => return Ok(None), // EOF
                 Ok(n) => total_read += n,
                 Err(e) => return Err(CaptureError::Io(e)),
@@ -150,8 +244,7 @@ impl VideoSource {
 
 impl Drop for VideoSource {
     fn drop(&mut self) {
-        let _ = self.child.kill();
-        let _ = self.child.wait();
+        end_child_by_pid(self.child_pid);
     }
 }
 


### PR DESCRIPTION
Added `POST /api/mutations/restart` which allows to replace the process image with a fresh copy of itself (`exec`): the PID stays, so it behaves the same under systemd, in a container, or from a terminal. It saves nothing first - unsaved zones stay unsaved, a config edited over SSH is picked up as written; the reply is sent before the restart, so wait for `/api/ping`.

Since `exec` runs no destructors, the capture subprocess is now shut down explicitly, and the same path serves Ctrl-C and normal exit: SIGINT, two seconds to go on its own, then SIGKILL, then reaped. SIGINT rather than SIGTERM because that is what these programs answer - `gst-launch-1.0` exits 0 with the pipeline taken down on SIGINT and 143 killed outright on SIGTERM; on a Jetson CSI camera only the orderly teardown closes the Argus session. The `Child` moved into a registry (`VideoSource` keeps just the stdout pipe): only a parent can reap a child, and after `exec` nobody is left to do it.

Also there is an important note about `systemd` in README: use `KillMode=mixed` in that case.