### PR TITLE
Track configuration change via API

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,7 +335,37 @@ Locally you can access Swagger UI documentation via http://localhost:42001/api/d
         reset_data_milliseconds = 30000
     ```
 
-13. Restarting
+13. Status
+
+    `GET /api/status` answers the questions that would otherwise need an SSH session: which source is being read and whether frames are getting through, what the inference runs on, how objects are tracked, where statistics are published, where the log goes, and what went wrong last.
+
+    ```shell
+    curl http://localhost:42001/api/status
+    ```
+
+    ```json
+    {
+      "equipment_id": "1e23985f-1fa3-45d0-a365-2d8525a23ddd",
+      "version": "0.3.1",
+      "uptime_seconds": 42,
+      "input": {"video_src": "rtsp://...", "kind": "live", "width": 1280, "height": 720, "fps": 30.0,
+                "process_every_nth_frame": 2, "frames_processed": 542, "frames_dropped": 0,
+                "processing_fps": 14.9, "last_frame_at": 36.1},
+      "detection": {"backend": "ort", "cuda_available": true, "model": "./data/model.onnx",
+                    "net_width": 416, "net_height": 256, "inference_ms": 7.4,
+                    "postprocess_ms": 0.01, "tracking_ms": 0.01},
+      "tracking": {"description": "BBox tracker (8D Kalman: ...) with ByteTracker engine, tracks expire after 2 s unmatched"},
+      "redis": {"enabled": false, "host": "localhost", "port": 6379, "channel": "DETECTORS_STATISTICS"},
+      "logging": {"level": "info", "file": "./logs/rust-road-traffic.log"},
+      "last_problem": null
+    }
+    ```
+
+    `processing_fps` is measured over the last second, so it shows what the detector keeps up with rather than what the source promises; `frames_dropped` counts the frames a busy detector never got to, and is always 0 for a video file. `last_problem` is the most recent warning or error as it went into the log, with its `scope`, or `null` if there was none.
+
+    `restart_required` and `pending_changes` compare the saved configuration with the one this run started with, so a change made through `PUT /api/config` stays visible until it is actually applied — the answer to the `PUT` is gone as soon as the page reloads, this is not.
+
+14. Restarting
 
     Some settings are only read at startup: the video source, the tracker, Redis publisher and the statistics refresher period. API `POST /api/mutations/restart` restarts the application to pick them up, without knowing what supervises it:
 
@@ -350,7 +380,7 @@ Locally you can access Swagger UI documentation via http://localhost:42001/api/d
 
     Under systemd, add `KillMode=mixed` to the unit so that stopping the service signals this process alone and lets it shut its pipeline down; with the default `control-group` systemd signals `gst-launch-1.0` directly, which kills it with the pipeline still up.
 
-14. Logging
+15. Logging
 
     Logs are NDJSON (one JSON object per line) on stdout and, by default, in `./logs/rust-road-traffic.log` next to the config file. Every line carries `level` (`INFO`, `WARN`, `ERROR`), `scope` (`startup`, `capture`, `processing`, `analytics`, `redis`, `rest_api`, `report`, `dataset`) and the message with its fields:
 
@@ -372,6 +402,39 @@ Locally you can access Swagger UI documentation via http://localhost:42001/api/d
     ```
 
     The `RUST_LOG` environment variable overrides `level`. A folder that can't be written to never stops the app: it logs to stdout only and says why.
+
+    The same lines are readable over the API, which is what the file is for: it is rotated, kept on disk and survives a restart, which is exactly when one wants to see what came before.
+
+    ```shell
+    curl "http://localhost:42001/api/logs?limit=50&level=warn&scope=capture"
+    ```
+
+    `limit` is 200 by default and 5000 at most, `level` is the lowest severity to include, `scope` matches one of the scopes above. Entries come oldest first, and rotated files are read as well when the current one is not enough.
+
+16. Configuration over the API
+
+    `GET /api/config` returns the settings as the file has them, without the zones (they have their own endpoints) and without the Redis password, which shows up as `password_set` instead.
+
+    `PUT /api/config` changes them. Only the keys present in the request are touched, the file is written at once, and the answer says what really changed and whether a restart is due:
+
+    ```shell
+    curl -X PUT -H 'Content-Type: application/json' \
+        -d '{"input": {"video_src": "rtsp://cam/stream"}, "verbose": {"level": "debug"}}' \
+        http://localhost:42001/api/config
+    # {"message":"ok","restart_required":true,"changed":["input.video_src","verbose.level"]}
+    ```
+
+    Almost everything is read once, when the piece that uses it is built, so changing it needs `POST /api/mutations/restart`. The log level is the exception: it applies immediately, and a request that only changes it answers `restart_required: false`. What is still waiting for a restart is also reported by `GET /api/status`, as `restart_required` and `pending_changes`. Values are validated the same way as when the file is loaded, and a request that would not make sense is rejected with 400 and left unsaved.
+
+    Redis can be tried before it is saved:
+
+    ```shell
+    curl -X POST -H 'Content-Type: application/json' -d '{"host": "10.0.0.2", "port": 6379}' \
+        http://localhost:42001/api/redis/check
+    # {"ok":false,"took_ms":1,"target":"10.0.0.2:6379/0","error":"Connection refused (os error 111)"}
+    ```
+
+    Anything left out of the request is taken from the current configuration, so an empty body checks what the app is set up to use.
 
 ## Virtual lines
 

--- a/src/lib/detection/detector.rs
+++ b/src/lib/detection/detector.rs
@@ -65,6 +65,22 @@ pub enum Detector {
 }
 
 impl Detector {
+    /// Which inference backend this build ended up with
+    pub fn backend(&self) -> &'static str {
+        match self {
+            #[cfg(feature = "opencv-backend")]
+            Detector::OpenCV(_) => "opencv",
+            #[cfg(all(feature = "ort-backend", not(feature = "opencv-backend")))]
+            Detector::Ort(_) => "ort",
+            #[cfg(all(
+                feature = "tensorrt-backend",
+                not(feature = "opencv-backend"),
+                not(feature = "ort-backend")
+            ))]
+            Detector::TensorRT(_) => "tensorrt",
+        }
+    }
+
     #[cfg(feature = "opencv-backend")]
     pub fn new(
         weights: &str,

--- a/src/lib/logging.rs
+++ b/src/lib/logging.rs
@@ -1,14 +1,19 @@
 //! NDJSON logging to stdout and to a rotated file, configured by `[verbose]`
+use std::fmt::Debug;
 use std::path::{Path, PathBuf};
-use std::sync::OnceLock;
+use std::sync::{OnceLock, RwLock};
 
-use tracing::{info, warn};
+use serde::Serialize;
+use tracing::field::{Field, Visit};
+use tracing::{Event, Level, Subscriber, info, warn};
+use tracing_subscriber::layer::Context;
 use tracing_subscriber::{
     EnvFilter, Layer, Registry, fmt,
     layer::{Layered, SubscriberExt},
     reload,
     util::SubscriberInitExt,
 };
+use utoipa::ToSchema;
 
 pub const LOG_FILE_NAME: &str = "rust-road-traffic.log";
 
@@ -34,7 +39,74 @@ type FileLayer = Box<dyn Layer<Registry> + Send + Sync + 'static>;
 type WithFile = Layered<reload::Layer<Option<FileLayer>, Registry>, Registry>;
 
 static FILE_HANDLE: OnceLock<reload::Handle<Option<FileLayer>, Registry>> = OnceLock::new();
+static LAST_PROBLEM: RwLock<Option<LoggedProblem>> = RwLock::new(None);
 static FILTER_HANDLE: OnceLock<reload::Handle<EnvFilter, WithFile>> = OnceLock::new();
+
+/// The most recent warning or error, as it went into the log
+#[derive(Debug, Clone, Serialize, ToSchema)]
+pub struct LoggedProblem {
+    /// "WARN" or "ERROR"
+    pub level: String,
+    /// Which part of the app it came from, see the `SCOPE_*` constants
+    pub scope: Option<String>,
+    pub message: String,
+    /// When it happened, RFC 3339
+    pub at: String,
+}
+
+/// The last warning or error since the app started, if there was one.
+///
+/// Remembered by a log layer rather than by the code that reports the problem,
+/// so every message ever logged counts, including the ones added later
+pub fn last_problem() -> Option<LoggedProblem> {
+    LAST_PROBLEM.read().ok().and_then(|last| last.clone())
+}
+
+/// Keeps the last warning or error around for `GET /api/status`
+struct LastProblemLayer;
+
+impl<S: Subscriber> Layer<S> for LastProblemLayer {
+    fn on_event(&self, event: &Event<'_>, _ctx: Context<'_, S>) {
+        let level = *event.metadata().level();
+        if level != Level::WARN && level != Level::ERROR {
+            return;
+        }
+        let mut fields = ProblemFields::default();
+        event.record(&mut fields);
+        if let Ok(mut last) = LAST_PROBLEM.write() {
+            *last = Some(LoggedProblem {
+                level: level.to_string(),
+                scope: fields.scope,
+                message: fields.message,
+                at: chrono::Utc::now().to_rfc3339(),
+            });
+        }
+    }
+}
+
+/// Picks the message and the scope out of a log event, ignoring the rest
+#[derive(Default)]
+struct ProblemFields {
+    message: String,
+    scope: Option<String>,
+}
+
+impl Visit for ProblemFields {
+    fn record_str(&mut self, field: &Field, value: &str) {
+        match field.name() {
+            "message" => self.message = value.to_string(),
+            "scope" => self.scope = Some(value.to_string()),
+            _ => {}
+        }
+    }
+    fn record_debug(&mut self, field: &Field, value: &dyn Debug) {
+        match field.name() {
+            "message" => self.message = format!("{value:?}"),
+            "scope" => self.scope = Some(format!("{value:?}")),
+            _ => {}
+        }
+    }
+}
 
 /// Resolved logging configuration, see `VerboseSettings`
 pub struct LogConfig {
@@ -64,6 +136,7 @@ pub fn init_logger() {
         .with(file_layer)
         .with(filter_layer)
         .with(json_layer().with_writer(std::io::stdout))
+        .with(LastProblemLayer)
         .init();
     let _ = FILE_HANDLE.set(file_handle);
     let _ = FILTER_HANDLE.set(filter_handle);
@@ -88,9 +161,12 @@ pub fn apply_config(config: &LogConfig) -> Option<tracing_appender::non_blocking
     let mut guard = None;
     let mut log_file = None;
     let mut folder_problem = None;
+    let mut dropped_files = Vec::new();
     if let Some(folder) = &config.logs_folder {
         match open_log_file(folder, config) {
             Ok(appender) => {
+                dropped_files =
+                    drop_extra_rotated_files(&folder.join(LOG_FILE_NAME), config.max_files);
                 let (writer, worker_guard) = tracing_appender::non_blocking(appender);
                 let layer: FileLayer = Box::new(json_layer().with_writer(writer));
                 match FILE_HANDLE.get().map(|handle| handle.reload(Some(layer))) {
@@ -122,6 +198,14 @@ pub fn apply_config(config: &LogConfig) -> Option<tracing_appender::non_blocking
             "Can't write log files there, logging to stdout only"
         );
     }
+    if !dropped_files.is_empty() {
+        info!(
+            scope = SCOPE_STARTUP,
+            files = ?dropped_files,
+            max_files = config.max_files,
+            "Removed rotated log files that the configured retention no longer keeps"
+        );
+    }
     info!(
         scope = SCOPE_STARTUP,
         level = config.level,
@@ -146,6 +230,39 @@ where
         .with_file(false)
         .with_line_number(false)
         .with_ansi(false)
+}
+
+/// Removes the rotated files that fall outside the retention now configured.
+///
+/// Rotation only ever touches the numbers it still keeps, so lowering
+/// `max_files` would otherwise leave `<name>.3`, `<name>.4` and the rest on
+/// disk for good: invisible to the log API and never cleaned up again
+fn drop_extra_rotated_files(base: &Path, max_files: usize) -> Vec<String> {
+    let (Some(folder), Some(name)) = (base.parent(), base.file_name().and_then(|n| n.to_str()))
+    else {
+        return Vec::new();
+    };
+    let Ok(entries) = std::fs::read_dir(folder) else {
+        return Vec::new();
+    };
+    let mut removed = Vec::new();
+    for entry in entries.flatten() {
+        let file_name = entry.file_name();
+        let Some(file_name) = file_name.to_str() else {
+            continue;
+        };
+        let Some(index) = file_name
+            .strip_prefix(&format!("{name}."))
+            .and_then(|index| index.parse::<usize>().ok())
+        else {
+            continue;
+        };
+        if index > max_files && std::fs::remove_file(entry.path()).is_ok() {
+            removed.push(file_name.to_string());
+        }
+    }
+    removed.sort();
+    removed
 }
 
 /// Makes sure the folder exists, is a directory and the log file in it can be
@@ -236,6 +353,36 @@ mod tests {
 
         let nowhere = PathBuf::from("/dev/null/logs");
         assert!(open_log_file(&nowhere, &config(None)).is_err());
+    }
+
+    #[test]
+    fn lowering_the_retention_removes_the_extra_files() {
+        let folder = std::env::temp_dir().join(format!("rrt_retention_{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&folder);
+        std::fs::create_dir_all(&folder).unwrap();
+        let base = folder.join(LOG_FILE_NAME);
+        std::fs::write(&base, b"current").unwrap();
+        for index in 1..=5 {
+            std::fs::write(format!("{}.{index}", base.display()), b"old").unwrap();
+        }
+        // Anything else in the folder must be left alone
+        std::fs::write(folder.join("notes.txt"), b"keep me").unwrap();
+
+        let removed = drop_extra_rotated_files(&base, 2);
+        assert_eq!(
+            removed,
+            [
+                format!("{LOG_FILE_NAME}.3"),
+                format!("{LOG_FILE_NAME}.4"),
+                format!("{LOG_FILE_NAME}.5")
+            ]
+        );
+        assert!(base.is_file());
+        assert!(PathBuf::from(format!("{}.1", base.display())).is_file());
+        assert!(PathBuf::from(format!("{}.2", base.display())).is_file());
+        assert!(!PathBuf::from(format!("{}.3", base.display())).exists());
+        assert!(folder.join("notes.txt").is_file());
+        let _ = std::fs::remove_dir_all(&folder);
     }
 
     #[test]

--- a/src/lib/mod.rs
+++ b/src/lib/mod.rs
@@ -11,6 +11,7 @@ pub mod publisher;
 pub mod report;
 pub mod restart;
 pub mod spatial;
+pub mod status;
 pub mod tracker;
 pub mod utils;
 pub mod zones;

--- a/src/lib/status.rs
+++ b/src/lib/status.rs
@@ -1,0 +1,222 @@
+//! What the running application can tell about itself, for `GET /api/status`
+use std::sync::RwLock;
+use std::time::Instant;
+
+use serde::Serialize;
+use utoipa::ToSchema;
+
+/// Video source and how many frames are getting through
+#[derive(Debug, Clone, Default, Serialize, ToSchema)]
+pub struct InputStatus {
+    /// The `video_src` from the configuration
+    pub video_src: String,
+    /// "live" for a camera or a stream, "file" for a video file
+    pub kind: String,
+    pub width: u32,
+    pub height: u32,
+    /// Frame rate the source reports
+    pub fps: f32,
+    /// Frames in the file, -1 for a live source
+    pub total_frames: f32,
+    /// Only every N-th decoded frame is processed
+    pub process_every_nth_frame: u64,
+    /// Frames the detector has processed since start
+    pub frames_processed: u64,
+    /// Frames dropped because the detector was busy. Live sources only
+    pub frames_dropped: u64,
+    /// Frames per second the detector actually keeps up with, measured over
+    /// the last second. `null` until the first second is over
+    pub processing_fps: Option<f32>,
+    /// Timestamp of the last processed frame, in seconds since capture start
+    pub last_frame_at: Option<f64>,
+}
+
+/// Inference backend and model
+#[derive(Debug, Clone, Default, Serialize, ToSchema)]
+pub struct DetectionStatus {
+    /// "opencv", "ort" or "tensorrt"
+    pub backend: String,
+    /// Whether a CUDA device was found at startup
+    pub cuda_available: bool,
+    pub model: String,
+    pub net_width: Option<i32>,
+    pub net_height: Option<i32>,
+    /// How long the last frame took, in milliseconds
+    pub inference_ms: Option<f32>,
+    pub postprocess_ms: Option<f32>,
+    pub tracking_ms: Option<f32>,
+}
+
+/// Tracker in use
+#[derive(Debug, Clone, Default, Serialize, ToSchema)]
+pub struct TrackingStatus {
+    /// Human-readable description, the same one that goes into the log at startup
+    pub description: String,
+}
+
+/// Everything the app learns about itself while it runs.
+///
+/// Shared between the detection loop, which writes, and the REST API, which
+/// reads: the two live in different threads and neither can reach the other's
+/// locals
+#[derive(Debug)]
+pub struct RuntimeStatus {
+    started: Instant,
+    input: RwLock<InputStatus>,
+    detection: RwLock<DetectionStatus>,
+    tracking: RwLock<TrackingStatus>,
+    /// Frames counted towards the current one-second rate window
+    rate_window: RwLock<RateWindow>,
+}
+
+#[derive(Debug)]
+struct RateWindow {
+    started: Instant,
+    frames: u64,
+}
+
+impl Default for RuntimeStatus {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl RuntimeStatus {
+    pub fn new() -> Self {
+        let now = Instant::now();
+        RuntimeStatus {
+            started: now,
+            input: RwLock::new(InputStatus::default()),
+            detection: RwLock::new(DetectionStatus::default()),
+            tracking: RwLock::new(TrackingStatus::default()),
+            rate_window: RwLock::new(RateWindow {
+                started: now,
+                frames: 0,
+            }),
+        }
+    }
+
+    pub fn uptime_seconds(&self) -> u64 {
+        self.started.elapsed().as_secs()
+    }
+
+    /// Records what the video source turned out to be, once it is open
+    pub fn set_input(&self, input: InputStatus) {
+        if let Ok(mut current) = self.input.write() {
+            *current = input;
+        }
+    }
+
+    pub fn set_detection(&self, detection: DetectionStatus) {
+        if let Ok(mut current) = self.detection.write() {
+            *current = detection;
+        }
+    }
+
+    pub fn set_tracking(&self, description: String) {
+        if let Ok(mut current) = self.tracking.write() {
+            current.description = description;
+        }
+    }
+
+    /// Records a processed frame: its timings, the timestamp it carried and the
+    /// total number of frames dropped so far. The processing rate is measured
+    /// over one-second windows rather than over the whole uptime, so that it
+    /// reflects what the detector is doing now
+    pub fn frame_processed(
+        &self,
+        timestamp: f64,
+        dropped_total: u64,
+        inference_ms: f32,
+        postprocess_ms: f32,
+        tracking_ms: f32,
+    ) {
+        let measured_fps = self.tick_rate();
+        if let Ok(mut input) = self.input.write() {
+            input.frames_processed += 1;
+            input.frames_dropped = dropped_total;
+            input.last_frame_at = Some(timestamp);
+            if let Some(fps) = measured_fps {
+                input.processing_fps = Some(fps);
+            }
+        }
+        if let Ok(mut detection) = self.detection.write() {
+            detection.inference_ms = Some(inference_ms);
+            detection.postprocess_ms = Some(postprocess_ms);
+            detection.tracking_ms = Some(tracking_ms);
+        }
+    }
+
+    /// Counts the frame into the current window and closes the window once a
+    /// second has passed, returning the rate it measured
+    fn tick_rate(&self) -> Option<f32> {
+        let mut window = self.rate_window.write().ok()?;
+        window.frames += 1;
+        let elapsed = window.started.elapsed();
+        if elapsed.as_secs_f32() < 1.0 {
+            return None;
+        }
+        let fps = window.frames as f32 / elapsed.as_secs_f32();
+        window.started = Instant::now();
+        window.frames = 0;
+        Some(fps)
+    }
+
+    pub fn input(&self) -> InputStatus {
+        self.input.read().map(|i| i.clone()).unwrap_or_default()
+    }
+
+    pub fn detection(&self) -> DetectionStatus {
+        self.detection.read().map(|d| d.clone()).unwrap_or_default()
+    }
+
+    pub fn tracking(&self) -> TrackingStatus {
+        self.tracking.read().map(|t| t.clone()).unwrap_or_default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn frames_and_timings_are_recorded() {
+        let status = RuntimeStatus::new();
+        status.set_input(InputStatus {
+            video_src: "x.mp4".to_string(),
+            kind: "file".to_string(),
+            ..Default::default()
+        });
+        status.frame_processed(0.5, 3, 7.0, 0.5, 0.1);
+        status.frame_processed(1.0, 4, 8.0, 0.5, 0.1);
+
+        let input = status.input();
+        assert_eq!(input.video_src, "x.mp4");
+        assert_eq!(input.frames_processed, 2);
+        assert_eq!(input.frames_dropped, 4);
+        assert_eq!(input.last_frame_at, Some(1.0));
+        // Less than a second has passed, so there is no rate to report yet
+        assert_eq!(input.processing_fps, None);
+
+        let detection = status.detection();
+        assert_eq!(detection.inference_ms, Some(8.0));
+        assert_eq!(detection.tracking_ms, Some(0.1));
+    }
+
+    #[test]
+    fn rate_is_measured_once_the_window_is_over() {
+        let status = RuntimeStatus::new();
+        status.frame_processed(0.0, 0, 1.0, 0.0, 0.0);
+        assert_eq!(status.input().processing_fps, None);
+        std::thread::sleep(std::time::Duration::from_millis(1050));
+        status.frame_processed(1.0, 0, 1.0, 0.0, 0.0);
+        let fps = status
+            .input()
+            .processing_fps
+            .expect("a full window must report a rate");
+        assert!(
+            (fps - 2.0).abs() < 0.5,
+            "two frames in about a second, got {fps}"
+        );
+    }
+}

--- a/src/lib/utils.rs
+++ b/src/lib/utils.rs
@@ -43,6 +43,35 @@ pub fn is_cuda_available() -> bool {
     Path::new("/dev/nvidia0").exists()
 }
 
+/// Hides the password in a source URL, so that an RTSP camera's credentials do
+/// not end up in the log or in an API answer: `rtsp://user:secret@host/stream`
+/// becomes `rtsp://user:***@host/stream`. Anything without credentials, a
+/// GStreamer pipeline included, is returned unchanged
+pub fn mask_credentials(source: &str) -> String {
+    let Some(scheme_end) = source.find("://") else {
+        return source.to_string();
+    };
+    let authority_start = scheme_end + 3;
+    let authority_end = source[authority_start..]
+        .find('/')
+        .map(|offset| authority_start + offset)
+        .unwrap_or(source.len());
+    let authority = &source[authority_start..authority_end];
+    let Some(at) = authority.rfind('@') else {
+        return source.to_string();
+    };
+    let credentials = &authority[..at];
+    let Some(colon) = credentials.find(':') else {
+        return source.to_string();
+    };
+    format!(
+        "{}{}:***{}",
+        &source[..authority_start],
+        &credentials[..colon],
+        &source[authority_start + at..]
+    )
+}
+
 /// Detected model file format.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub enum ModelFileFormat {
@@ -268,5 +297,24 @@ mod tests {
             "TensorRT engine"
         );
         assert_eq!(format!("{}", ModelFileFormat::Unknown), "Unknown");
+    }
+
+    #[test]
+    fn credentials_are_masked() {
+        assert_eq!(
+            mask_credentials("rtsp://cam:s3cret@10.0.0.5:554/stream"),
+            "rtsp://cam:***@10.0.0.5:554/stream"
+        );
+        // An @ in the path is not a credentials separator
+        assert_eq!(
+            mask_credentials("rtsp://10.0.0.5/live@main"),
+            "rtsp://10.0.0.5/live@main"
+        );
+        assert_eq!(mask_credentials("rtsp://host/stream"), "rtsp://host/stream");
+        assert_eq!(mask_credentials("./data/video.mp4"), "./data/video.mp4");
+        assert_eq!(
+            mask_credentials("v4l2src device=/dev/video0 ! appsink"),
+            "v4l2src device=/dev/video0 ! appsink"
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,7 @@ use lib::detection::process_yolo_detections;
 use lib::draw;
 use lib::logging;
 use lib::perf_stats::{PerfStats, Timer};
+use lib::status::{DetectionStatus, InputStatus, RuntimeStatus};
 use lib::tracker::{SpatialInfo, TrackerTrait, new_tracker_from_type};
 use lib::zones::Zone;
 
@@ -220,11 +221,16 @@ fn run(
     };
 
     /* Start REST API if needed */
+    // The API answers before the video source is even open, so what the app
+    // knows about itself is shared rather than passed: the detection loop
+    // fills it in as it learns
+    let status = std::sync::Arc::new(RuntimeStatus::new());
     let overwrite_file = path_to_config.to_string();
     let (tx_mjpeg, rx_mjpeg) = mpsc::sync_channel(0);
     if settings.rest_api.enable && !report_mode {
         let settings_clone = settings.clone();
         let ds_api = data_storage.clone();
+        let status_api = status.clone();
         thread::spawn(move || {
             match rest_api::start_rest_api(
                 settings_clone.rest_api.host.clone(),
@@ -234,6 +240,7 @@ fn run(
                 rx_mjpeg,
                 settings_clone,
                 &overwrite_file,
+                status_api,
             ) {
                 Ok(_) => {}
                 Err(err) => {
@@ -249,6 +256,15 @@ fn run(
     let height = video_source.height();
     let fps = video_source.fps();
     let total_frames = video_source.total_frames();
+    status.set_tracking(tracker.description());
+    status.set_detection(DetectionStatus {
+        backend: detector.backend().to_string(),
+        cuda_available: lib::utils::is_cuda_available(),
+        model: settings.detection.network_weights.clone(),
+        net_width: settings.detection.net_width,
+        net_height: settings.detection.net_height,
+        ..Default::default()
+    });
 
     // Initialize zone grid with frame dimensions
     {
@@ -275,6 +291,16 @@ fn run(
     // frame and drops the ones a slow detector did not get to (see frame_channel)
     let (tx_capture, rx_capture) = frame_channel(live_source);
     let skip_every_n_frame: u64 = settings.input.process_every_nth_frame.unwrap_or(2).max(1) as u64;
+    status.set_input(InputStatus {
+        video_src: settings.input.video_src.clone(),
+        kind: if live_source { "live" } else { "file" }.to_string(),
+        width: width as u32,
+        height: height as u32,
+        fps,
+        total_frames,
+        process_every_nth_frame: skip_every_n_frame,
+        ..Default::default()
+    });
     thread::spawn(move || {
         let mut frame_idx: u64 = 0;
         let mut processed_frames: u32 = 0;
@@ -490,8 +516,15 @@ fn run(
         let tracking_time = t_tracking.elapsed();
 
         /* Record performance stats */
+        let dropped_total = rx_capture.dropped();
+        status.frame_processed(
+            received.timestamp,
+            dropped_total,
+            inference_time.as_secs_f32() * 1000.0,
+            postprocess_time.as_secs_f32() * 1000.0,
+            tracking_time.as_secs_f32() * 1000.0,
+        );
         if let Some(ref mut stats) = perf_stats {
-            let dropped_total = rx_capture.dropped();
             stats.record(
                 inference_time,
                 postprocess_time,
@@ -845,10 +878,13 @@ fn main() {
             std::process::exit(1);
         }
     }
+    // The source is masked here and nowhere else: a log file outlives the
+    // process and gets copied into tickets and mailboxes, while the API returns
+    // the configuration as it is, since it has no authentication to hide behind
     info!(
         scope = logging::SCOPE_STARTUP,
         equipment_id = %app_settings.equipment_info.id,
-        video_src = %app_settings.input.video_src,
+        video_src = %lib::utils::mask_credentials(&app_settings.input.video_src),
         network_weights = %app_settings.detection.network_weights,
         tracker = app_settings.tracking.typ.as_deref().unwrap_or("iou_naive"),
         kalman_filter = app_settings.tracking.kalman_filter.as_deref().unwrap_or("centroid"),

--- a/src/rest_api/config.rs
+++ b/src/rest_api/config.rs
@@ -1,0 +1,222 @@
+use actix_web::{Error, HttpResponse, web};
+use serde::Serialize;
+use serde_json::{Map, Value};
+use tracing::info;
+use utoipa::ToSchema;
+
+use crate::lib::logging;
+use crate::rest_api::APIStorage;
+use crate::settings::{AppSettings, ZONES_KEY, changed_paths, needs_restart};
+
+/// Error response
+#[derive(Debug, Serialize, ToSchema)]
+pub struct ErrorResponse {
+    /// What was wrong with the request
+    #[schema(example = "Invalid tracker type: 'sort'. Supported: iou_naive, bytetrack")]
+    pub error_text: String,
+}
+
+/// Result of a configuration change
+#[derive(Debug, Serialize, ToSchema)]
+pub struct UpdateConfigResponse {
+    #[schema(example = "ok")]
+    pub message: &'static str,
+    /// Whether the application has to be restarted for the change to take
+    /// effect: `POST /api/mutations/restart`
+    pub restart_required: bool,
+    /// Dotted paths of the settings that actually changed
+    #[schema(example = json!(["input.video_src"]))]
+    pub changed: Vec<String>,
+}
+
+#[utoipa::path(
+    get,
+    tag = "Configuration",
+    path = "/api/config",
+    responses(
+        (status = 200, description = "Current configuration, without the zones and the Redis password", body = Object)
+    )
+)]
+/// The configuration as the file has it, minus the zones (they have their own
+/// endpoints) and minus the Redis password, which is reported as
+/// `password_set` instead of being handed out
+pub async fn get_config(data: web::Data<APIStorage>) -> Result<HttpResponse, Error> {
+    let settings = data
+        .app_settings
+        .read()
+        .expect("Settings are poisoned [RwLock]");
+    let value = match public_view(&settings) {
+        Ok(value) => value,
+        Err(err) => {
+            return Ok(HttpResponse::InternalServerError().json(ErrorResponse {
+                error_text: format!("Can't read the configuration: {}", err),
+            }));
+        }
+    };
+    Ok(HttpResponse::Ok().json(value))
+}
+
+#[utoipa::path(
+    put,
+    tag = "Configuration",
+    path = "/api/config",
+    request_body(content = Object, description = "The sections and keys to change, e.g. {\"input\": {\"video_src\": \"rtsp://...\"}}"),
+    responses(
+        (status = 200, description = "Saved to the configuration file", body = UpdateConfigResponse),
+        (status = 400, description = "The request asks for something the app would not accept", body = ErrorResponse),
+        (status = 500, description = "Can't write the configuration file", body = ErrorResponse)
+    )
+)]
+/// Changes settings and writes them to the configuration file at once, so that
+/// the change survives the restart it usually needs. Only the keys present in
+/// the request are touched; the answer says which ones actually changed and
+/// whether a restart is due
+pub async fn update_config(
+    data: web::Data<APIStorage>,
+    patch: web::Json<Value>,
+) -> Result<HttpResponse, Error> {
+    let mut settings = data
+        .app_settings
+        .write()
+        .expect("Settings are poisoned [RwLock]");
+
+    let patch = patch.into_inner();
+    if !patch.is_object() {
+        return Ok(HttpResponse::BadRequest().json(ErrorResponse {
+            error_text: "Expected an object with the sections to change".to_string(),
+        }));
+    }
+    if patch.get(ZONES_KEY).is_some() {
+        return Ok(HttpResponse::BadRequest().json(ErrorResponse {
+            error_text: "Zones are changed through /api/mutations/zones/*, not here".to_string(),
+        }));
+    }
+
+    let current = match serde_json::to_value(&*settings) {
+        Ok(value) => value,
+        Err(err) => {
+            return Ok(HttpResponse::InternalServerError().json(ErrorResponse {
+                error_text: format!("Can't read the configuration: {}", err),
+            }));
+        }
+    };
+    let mut merged = current.clone();
+    merge(&mut merged, &patch);
+
+    let updated: AppSettings = match serde_json::from_value(merged.clone()) {
+        Ok(settings) => settings,
+        Err(err) => {
+            return Ok(HttpResponse::BadRequest().json(ErrorResponse {
+                error_text: format!("The configuration would not make sense: {}", err),
+            }));
+        }
+    };
+    if let Err(err) = updated.validate() {
+        return Ok(HttpResponse::BadRequest().json(ErrorResponse {
+            error_text: err.to_string(),
+        }));
+    }
+
+    let mut changed = Vec::new();
+    changed_paths(&current, &merged, "", &mut changed);
+    changed.retain(|path| path != ZONES_KEY && !path.starts_with(&format!("{ZONES_KEY}.")));
+    if changed.is_empty() {
+        return Ok(HttpResponse::Ok().json(UpdateConfigResponse {
+            message: "ok",
+            restart_required: false,
+            changed,
+        }));
+    }
+
+    if let Err(err) = updated.save(&data.settings_filename) {
+        return Ok(HttpResponse::InternalServerError().json(ErrorResponse {
+            error_text: format!("Can't save the configuration file: {}", err),
+        }));
+    }
+    *settings = updated;
+
+    // Whatever can be applied right away, is: the rest waits for a restart
+    if changed.iter().any(|path| path == "verbose.level") {
+        if let Some(level) = settings.verbose.as_ref().and_then(|v| v.level.as_deref()) {
+            logging::set_log_level(level);
+        }
+    }
+    let restart_required = changed.iter().any(|path| needs_restart(path));
+    info!(
+        scope = logging::SCOPE_REST_API,
+        changed = ?changed,
+        restart_required,
+        file = %data.settings_filename,
+        "Configuration updated"
+    );
+    Ok(HttpResponse::Ok().json(UpdateConfigResponse {
+        message: "ok",
+        restart_required,
+        changed,
+    }))
+}
+
+/// The settings as JSON, with the zones dropped and the Redis password replaced
+/// by whether there is one
+fn public_view(settings: &AppSettings) -> Result<Value, serde_json::Error> {
+    let mut value = serde_json::to_value(settings)?;
+    if let Some(object) = value.as_object_mut() {
+        object.remove(ZONES_KEY);
+        if let Some(Value::Object(redis)) = object.get_mut("redis_publisher") {
+            let has_password = redis
+                .get("password")
+                .and_then(Value::as_str)
+                .is_some_and(|password| !password.is_empty());
+            redis.remove("password");
+            redis.insert("password_set".to_string(), Value::Bool(has_password));
+        }
+    }
+    Ok(value)
+}
+
+/// Copies the values of `patch` into `base`, going into objects rather than
+/// replacing them, so that a request may name a single key of a section
+fn merge(base: &mut Value, patch: &Value) {
+    match (base, patch) {
+        (Value::Object(base), Value::Object(patch)) => {
+            for (key, value) in patch {
+                match base.get_mut(key) {
+                    Some(existing) => merge(existing, value),
+                    None => {
+                        base.insert(key.clone(), value.clone());
+                    }
+                }
+            }
+        }
+        (base, patch) => *base = patch.clone(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn json(text: &str) -> Value {
+        serde_json::from_str(text).unwrap()
+    }
+
+    #[test]
+    fn merge_goes_into_sections() {
+        let mut base = json(r#"{"input":{"video_src":"a.mp4","nth":2},"worker":{"ms":30}}"#);
+        merge(&mut base, &json(r#"{"input":{"video_src":"rtsp://x"}}"#));
+        assert_eq!(
+            base,
+            json(r#"{"input":{"video_src":"rtsp://x","nth":2},"worker":{"ms":30}}"#)
+        );
+    }
+
+    #[test]
+    fn merge_adds_missing_keys() {
+        let mut base = json(r#"{"tracking":{"type":"iou_naive"}}"#);
+        merge(&mut base, &json(r#"{"tracking":{"max_lost_seconds":2.0}}"#));
+        assert_eq!(
+            base,
+            json(r#"{"tracking":{"type":"iou_naive","max_lost_seconds":2.0}}"#)
+        );
+    }
+}

--- a/src/rest_api/logs.rs
+++ b/src/rest_api/logs.rs
@@ -1,0 +1,377 @@
+use std::fs::File;
+use std::io::{Read, Seek, SeekFrom};
+use std::path::{Path, PathBuf};
+
+use actix_web::{Error, HttpResponse, web};
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value};
+use utoipa::{IntoParams, ToSchema};
+
+use crate::rest_api::APIStorage;
+
+/// Never read more than this from one file: the tail is what anyone wants, and
+/// a log file is allowed to be tens of megabytes
+const MAX_SCAN_BYTES: u64 = 1024 * 1024;
+const DEFAULT_LIMIT: usize = 200;
+const MAX_LIMIT: usize = 5000;
+
+/// One line of the log file
+#[derive(Debug, Serialize, ToSchema)]
+pub struct LogEntry {
+    /// When it was written, RFC 3339
+    pub timestamp: Option<String>,
+    /// "ERROR", "WARN", "INFO" or "DEBUG"
+    pub level: String,
+    /// Which part of the app it came from
+    pub scope: Option<String>,
+    pub message: String,
+    /// Whatever else the line carried
+    #[schema(value_type = Object)]
+    pub fields: Map<String, Value>,
+}
+
+/// Filters for the log request
+#[derive(Debug, Deserialize, IntoParams)]
+pub struct LogsQuery {
+    /// How many of the most recent entries to return. Default 200, at most 5000
+    pub limit: Option<usize>,
+    /// Lowest severity to include: "error", "warn", "info" or "debug"
+    pub level: Option<String>,
+    /// Only entries from this scope, e.g. "capture" or "analytics"
+    pub scope: Option<String>,
+}
+
+/// The most recent log entries
+#[derive(Debug, Serialize, ToSchema)]
+pub struct LogsResponse {
+    /// The file they were read from, `null` when the app only logs to stdout
+    pub file: Option<String>,
+    pub returned: usize,
+    /// Oldest first, so that reading them top to bottom follows the run
+    pub entries: Vec<LogEntry>,
+}
+
+#[utoipa::path(
+    get,
+    tag = "Application",
+    path = "/api/logs",
+    params(LogsQuery),
+    responses(
+        (status = 200, description = "Most recent log entries", body = LogsResponse)
+    )
+)]
+/// Returns the tail of the log file, so that what happened can be looked at
+/// without an SSH session. The file rather than an in-memory buffer: it is
+/// rotated and kept on disk, and it survives a restart, which is exactly when
+/// one wants to see what came before
+pub async fn logs(
+    data: web::Data<APIStorage>,
+    query: web::Query<LogsQuery>,
+) -> Result<HttpResponse, Error> {
+    let log_config = data
+        .app_settings
+        .read()
+        .expect("Settings are poisoned [RwLock]")
+        .verbose
+        .clone()
+        .unwrap_or_default()
+        .to_log_config(&data.settings_filename);
+    let Some(folder) = log_config.logs_folder else {
+        return Ok(HttpResponse::Ok().json(LogsResponse {
+            file: None,
+            returned: 0,
+            entries: Vec::new(),
+        }));
+    };
+    let file = folder.join(crate::lib::logging::LOG_FILE_NAME);
+    let limit = query.limit.unwrap_or(DEFAULT_LIMIT).clamp(1, MAX_LIMIT);
+    let min_rank = query.level.as_deref().and_then(severity_rank);
+    let entries = collect(
+        &file,
+        log_config.max_files,
+        limit,
+        min_rank,
+        query.scope.as_deref(),
+    );
+    Ok(HttpResponse::Ok().json(LogsResponse {
+        file: Some(file.display().to_string()),
+        returned: entries.len(),
+        entries,
+    }))
+}
+
+/// Walks the current log file and then the rotated ones, newest first, until
+/// enough matching entries are found; returns them oldest first
+fn collect(
+    file: &Path,
+    max_files: usize,
+    limit: usize,
+    min_rank: Option<u8>,
+    scope: Option<&str>,
+) -> Vec<LogEntry> {
+    let mut collected: Vec<LogEntry> = Vec::new();
+    for index in 0..=max_files {
+        let path = if index == 0 {
+            file.to_path_buf()
+        } else {
+            // rolling-file keeps the previous files as `<name>.1`, `<name>.2`, ...
+            PathBuf::from(format!("{}.{}", file.display(), index))
+        };
+        let Ok(text) = read_tail(&path, MAX_SCAN_BYTES) else {
+            continue;
+        };
+        let mut matching: Vec<LogEntry> = text
+            .lines()
+            .filter_map(parse_entry)
+            .filter(|entry| matches(entry, min_rank, scope))
+            .collect();
+        matching.reverse();
+        collected.append(&mut matching);
+        if collected.len() >= limit {
+            break;
+        }
+    }
+    collected.truncate(limit);
+    collected.reverse();
+    collected
+}
+
+/// Reads at most `max_bytes` from the end of the file, dropping the first line
+/// when it starts in the middle of one
+fn read_tail(path: &Path, max_bytes: u64) -> std::io::Result<String> {
+    let mut file = File::open(path)?;
+    let length = file.metadata()?.len();
+    let from = length.saturating_sub(max_bytes);
+    file.seek(SeekFrom::Start(from))?;
+    let mut bytes = Vec::new();
+    file.read_to_end(&mut bytes)?;
+    let text = String::from_utf8_lossy(&bytes).into_owned();
+    if from == 0 {
+        return Ok(text);
+    }
+    Ok(match text.find('\n') {
+        Some(newline) => text[newline + 1..].to_string(),
+        None => String::new(),
+    })
+}
+
+/// Turns a log line into an entry, pulling the message and the scope out of the
+/// fields and leaving the rest of them alone. A line that is not our own JSON
+/// is skipped
+fn parse_entry(line: &str) -> Option<LogEntry> {
+    let mut value: Value = serde_json::from_str(line).ok()?;
+    let object = value.as_object_mut()?;
+    let timestamp = object
+        .get("timestamp")
+        .and_then(Value::as_str)
+        .map(str::to_string);
+    let level = object.get("level").and_then(Value::as_str)?.to_string();
+    let mut fields = match object.remove("fields") {
+        Some(Value::Object(fields)) => fields,
+        _ => Map::new(),
+    };
+    let message = fields
+        .remove("message")
+        .and_then(|message| message.as_str().map(str::to_string))
+        .unwrap_or_default();
+    let scope = fields
+        .remove("scope")
+        .and_then(|scope| scope.as_str().map(str::to_string));
+    Some(LogEntry {
+        timestamp,
+        level,
+        scope,
+        message,
+        fields,
+    })
+}
+
+fn matches(entry: &LogEntry, min_rank: Option<u8>, scope: Option<&str>) -> bool {
+    if let Some(min) = min_rank {
+        if severity_rank(&entry.level).unwrap_or(0) < min {
+            return false;
+        }
+    }
+    match scope {
+        Some(wanted) => entry.scope.as_deref() == Some(wanted),
+        None => true,
+    }
+}
+
+/// How severe a level is, so that "warn" can mean "warnings and worse"
+fn severity_rank(level: &str) -> Option<u8> {
+    match level.trim().to_ascii_lowercase().as_str() {
+        "debug" | "trace" => Some(0),
+        "info" => Some(1),
+        "warn" | "warning" => Some(2),
+        "error" => Some(3),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    fn line(level: &str, scope: &str, message: &str) -> String {
+        format!(
+            r#"{{"timestamp":"2026-09-07T19:00:00Z","level":"{level}","fields":{{"message":"{message}","scope":"{scope}","extra":7}}}}"#
+        )
+    }
+
+    fn write_log(path: &Path, lines: &[String]) {
+        let mut file = File::create(path).unwrap();
+        for l in lines {
+            writeln!(file, "{l}").unwrap();
+        }
+    }
+
+    struct TempDir(PathBuf);
+
+    impl TempDir {
+        fn new(name: &str) -> Self {
+            let path =
+                std::env::temp_dir().join(format!("rrt_logs_{}_{}", name, std::process::id()));
+            let _ = std::fs::remove_dir_all(&path);
+            std::fs::create_dir_all(&path).unwrap();
+            TempDir(path)
+        }
+    }
+
+    impl Drop for TempDir {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+
+    #[test]
+    fn newest_entries_come_last_and_fields_are_kept() {
+        let dir = TempDir::new("tail");
+        let file = dir.0.join("app.log");
+        write_log(
+            &file,
+            &[
+                line("INFO", "startup", "one"),
+                line("WARN", "capture", "two"),
+                line("ERROR", "capture", "three"),
+            ],
+        );
+        let entries = collect(&file, 2, 10, None, None);
+        assert_eq!(
+            entries
+                .iter()
+                .map(|e| e.message.as_str())
+                .collect::<Vec<_>>(),
+            ["one", "two", "three"]
+        );
+        assert_eq!(entries[0].scope.as_deref(), Some("startup"));
+        assert_eq!(
+            entries[0].fields.get("extra").and_then(Value::as_i64),
+            Some(7)
+        );
+    }
+
+    #[test]
+    fn limit_keeps_the_most_recent() {
+        let dir = TempDir::new("limit");
+        let file = dir.0.join("app.log");
+        let lines: Vec<String> = (0..10)
+            .map(|i| line("INFO", "processing", &format!("m{i}")))
+            .collect();
+        write_log(&file, &lines);
+        let entries = collect(&file, 2, 3, None, None);
+        assert_eq!(
+            entries
+                .iter()
+                .map(|e| e.message.as_str())
+                .collect::<Vec<_>>(),
+            ["m7", "m8", "m9"]
+        );
+    }
+
+    #[test]
+    fn level_and_scope_filter() {
+        let dir = TempDir::new("filter");
+        let file = dir.0.join("app.log");
+        write_log(
+            &file,
+            &[
+                line("INFO", "capture", "info-capture"),
+                line("WARN", "capture", "warn-capture"),
+                line("ERROR", "redis", "error-redis"),
+            ],
+        );
+        let warnings = collect(&file, 2, 10, severity_rank("warn"), None);
+        assert_eq!(
+            warnings
+                .iter()
+                .map(|e| e.message.as_str())
+                .collect::<Vec<_>>(),
+            ["warn-capture", "error-redis"]
+        );
+        let capture = collect(&file, 2, 10, None, Some("capture"));
+        assert_eq!(
+            capture
+                .iter()
+                .map(|e| e.message.as_str())
+                .collect::<Vec<_>>(),
+            ["info-capture", "warn-capture"]
+        );
+    }
+
+    #[test]
+    fn rotated_files_fill_the_tail_and_missing_ones_are_skipped() {
+        let dir = TempDir::new("rotated");
+        let file = dir.0.join("app.log");
+        write_log(&file, &[line("INFO", "processing", "newest")]);
+        write_log(
+            &PathBuf::from(format!("{}.2", file.display())),
+            &[line("INFO", "processing", "oldest")],
+        );
+        // `.1` is deliberately absent
+        let entries = collect(&file, 3, 10, None, None);
+        assert_eq!(
+            entries
+                .iter()
+                .map(|e| e.message.as_str())
+                .collect::<Vec<_>>(),
+            ["oldest", "newest"]
+        );
+    }
+
+    #[test]
+    fn a_partial_first_line_is_dropped() {
+        let dir = TempDir::new("partial");
+        let file = dir.0.join("app.log");
+        write_log(
+            &file,
+            &[
+                line("INFO", "startup", "first"),
+                line("INFO", "startup", "second"),
+            ],
+        );
+        // Starts 20 bytes in, i.e. in the middle of the first line
+        let length = std::fs::metadata(&file).unwrap().len();
+        let text = read_tail(&file, length - 20).unwrap();
+        assert!(!text.contains("first"), "{text}");
+        assert!(text.contains("second"), "{text}");
+    }
+
+    #[test]
+    fn lines_that_are_not_ours_are_skipped() {
+        let dir = TempDir::new("garbage");
+        let file = dir.0.join("app.log");
+        write_log(
+            &file,
+            &[
+                "not json at all".to_string(),
+                r#"{"level":"INFO"}"#.to_string(),
+                line("INFO", "startup", "good"),
+            ],
+        );
+        let entries = collect(&file, 1, 10, None, None);
+        assert_eq!(entries.len(), 2);
+        assert_eq!(entries[1].message, "good");
+    }
+}

--- a/src/rest_api/mod.rs
+++ b/src/rest_api/mod.rs
@@ -1,8 +1,12 @@
+mod config;
+mod logs;
 mod mjpeg_client;
 mod mjpeg_page;
+mod redis_check;
 mod rest_api;
 mod restart;
 mod services;
+mod status;
 mod toml_mutations;
 mod zones_list;
 mod zones_mutations;

--- a/src/rest_api/redis_check.rs
+++ b/src/rest_api/redis_check.rs
@@ -1,0 +1,112 @@
+use std::time::{Duration, Instant};
+
+use actix_web::{Error, HttpResponse, web};
+use redis::Client;
+use serde::{Deserialize, Serialize};
+use tracing::info;
+use utoipa::ToSchema;
+
+use crate::lib::logging;
+use crate::rest_api::APIStorage;
+
+/// A check must answer quickly: it is there to tell a typo from a firewall,
+/// not to wait out a dead host
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(3);
+
+/// Where to try. Anything left out is taken from the current configuration, so
+/// an empty body checks what the app is set up to use
+#[derive(Debug, Default, Deserialize, ToSchema)]
+pub struct RedisCheckRequest {
+    pub host: Option<String>,
+    pub port: Option<i32>,
+    pub db_index: Option<i32>,
+    /// Leave it out to use the password already in the configuration
+    pub password: Option<String>,
+}
+
+/// Whether Redis answered
+#[derive(Debug, Serialize, ToSchema)]
+pub struct RedisCheckResponse {
+    pub ok: bool,
+    /// How long the connection and the PING took
+    pub took_ms: u64,
+    /// Where it tried, without the password
+    #[schema(example = "localhost:6379/0")]
+    pub target: String,
+    /// Why it did not work, `null` when it did
+    pub error: Option<String>,
+}
+
+#[utoipa::path(
+    post,
+    tag = "Configuration",
+    path = "/api/redis/check",
+    request_body = RedisCheckRequest,
+    responses(
+        (status = 200, description = "The attempt was made; `ok` says how it went", body = RedisCheckResponse)
+    )
+)]
+/// Tries to connect to Redis and PING it, so that a host, a port or a password
+/// can be checked before it is saved. Answers 200 either way: the request
+/// itself succeeded, `ok` says whether Redis did
+pub async fn check_redis(
+    data: web::Data<APIStorage>,
+    request: Option<web::Json<RedisCheckRequest>>,
+) -> Result<HttpResponse, Error> {
+    let request = request.map(web::Json::into_inner).unwrap_or_default();
+    let (host, port, db_index, password) = {
+        let settings = data
+            .app_settings
+            .read()
+            .expect("Settings are poisoned [RwLock]");
+        let redis = &settings.redis_publisher;
+        (
+            request.host.unwrap_or_else(|| redis.host.clone()),
+            request.port.unwrap_or(redis.port),
+            request.db_index.unwrap_or(redis.db_index),
+            request.password.unwrap_or_else(|| redis.password.clone()),
+        )
+    };
+    let target = format!("{host}:{port}/{db_index}");
+
+    let url = if password.is_empty() {
+        format!("redis://{host}:{port}/{db_index}")
+    } else {
+        format!("redis://:{password}@{host}:{port}/{db_index}")
+    };
+    // Connecting blocks, and the worker thread has other requests to serve
+    let outcome = web::block(move || {
+        let started = Instant::now();
+        let result = Client::open(url)
+            .and_then(|client| client.get_connection_with_timeout(CONNECT_TIMEOUT))
+            .and_then(|mut connection| redis::cmd("PING").query::<String>(&mut connection));
+        (result, started.elapsed())
+    })
+    .await;
+
+    let (result, took) = match outcome {
+        Ok(outcome) => outcome,
+        Err(err) => {
+            return Ok(HttpResponse::Ok().json(RedisCheckResponse {
+                ok: false,
+                took_ms: 0,
+                target,
+                error: Some(format!("Can't run the check: {err}")),
+            }));
+        }
+    };
+    let error = result.err().map(|err| err.to_string());
+    info!(
+        scope = logging::SCOPE_REDIS,
+        target = %target,
+        ok = error.is_none(),
+        took_ms = took.as_millis() as u64,
+        "Redis check"
+    );
+    Ok(HttpResponse::Ok().json(RedisCheckResponse {
+        ok: error.is_none(),
+        took_ms: took.as_millis() as u64,
+        target,
+        error,
+    }))
+}

--- a/src/rest_api/rest_api.rs
+++ b/src/rest_api/rest_api.rs
@@ -6,15 +6,23 @@ use tracing::info;
 
 use crate::lib::data_storage::ThreadedDataStorage;
 use crate::lib::mjpeg_streaming::Broadcaster;
+use crate::lib::status::RuntimeStatus;
 use crate::rest_api::services;
 use crate::settings::AppSettings;
 use std::sync::{Mutex, mpsc::Receiver};
 
 pub struct APIStorage {
     pub data_storage: ThreadedDataStorage,
-    pub app_settings: AppSettings,
+    /// Changed through `PUT /api/config`, so it is shared rather than owned:
+    /// the copy the detection loop started with stays as it was until a restart
+    pub app_settings: RwLock<AppSettings>,
+    /// The settings this run was started with. Comparing them with the ones
+    /// above is what tells a change apart from a change that has taken effect
+    pub running_settings: AppSettings,
     pub settings_filename: String,
     pub mjpeg_broadcaster: web::Data<Mutex<Broadcaster>>,
+    /// What the detection loop has learned about the run so far
+    pub status: Arc<RuntimeStatus>,
 }
 
 #[actix_web::main]
@@ -26,14 +34,17 @@ pub async fn start_rest_api(
     rx_frames_data: Receiver<Vec<u8>>,
     app_settings: AppSettings,
     settings_filename: &str,
+    status: Arc<RuntimeStatus>,
 ) -> std::io::Result<()> {
     let bind_address = format!("{}:{}", server_host, server_port);
     info!(scope = logging::SCOPE_REST_API, host = %server_host, port = server_port, "REST API starting");
     let storage = APIStorage {
         data_storage: data_storage,
-        app_settings: app_settings,
+        running_settings: app_settings.clone(),
+        app_settings: RwLock::new(app_settings),
         settings_filename: settings_filename.to_string(),
         mjpeg_broadcaster: web::Data::new(Mutex::new(Broadcaster::default())),
+        status: status,
     };
 
     /* Enable MJPEG streaming server if needed */

--- a/src/rest_api/services.rs
+++ b/src/rest_api/services.rs
@@ -3,7 +3,8 @@ use actix_web_static_files::ResourceFiles;
 include!(concat!(env!("OUT_DIR"), "/generated.rs"));
 
 use crate::rest_api::{
-    mjpeg_client, mjpeg_page, restart, toml_mutations, zones_list, zones_mutations, zones_stats,
+    config, logs, mjpeg_client, mjpeg_page, redis_check, restart, status, toml_mutations,
+    zones_list, zones_mutations, zones_stats,
 };
 
 #[utoipa::path(
@@ -37,6 +38,16 @@ pub fn init_routes(enable_mjpeg: bool) -> impl Fn(&mut web::ServiceConfig) {
                 .service(RapiDoc::with_openapi("/docs.json", ApiDoc::openapi()))
                 .service(RapiDoc::new("/api/docs.json").path("/docs"))
                 .route("/ping", web::get().to(say_ping))
+                .route("/status", web::get().to(status::status))
+                .route("/logs", web::get().to(logs::logs))
+                .service(
+                    web::resource("/config")
+                        .route(web::get().to(config::get_config))
+                        .route(web::put().to(config::update_config)),
+                )
+                .service(
+                    web::scope("/redis").route("/check", web::post().to(redis_check::check_redis)),
+                )
                 .service(
                     web::scope("/polygons")
                         .route("/geojson", web::get().to(zones_list::all_zones_list)),
@@ -87,6 +98,11 @@ use utoipa_rapidoc::RapiDoc;
         zones_mutations::replace_all,
         toml_mutations::save_toml,
         restart::restart,
+        status::status,
+        logs::logs,
+        config::get_config,
+        config::update_config,
+        redis_check::check_redis,
         say_ping,
     ),
     tags(
@@ -94,6 +110,7 @@ use utoipa_rapidoc::RapiDoc;
         (name = "Statistics", description = "Aggregated and real-time statistics in the detections zones"),
         (name = "Zones mutations", description = "A way to mutate information about detection zones"),
         (name = "Application", description = "Managing the running application"),
+        (name = "Configuration", description = "Reading and changing the settings"),
     ),
     components(
         // We need to import all possible schemas since `utopia` can't discover recursive schemas (yet?)
@@ -121,6 +138,19 @@ use utoipa_rapidoc::RapiDoc;
             crate::rest_api::zones_mutations::ErrorResponse,
             crate::rest_api::toml_mutations::UpdateTOMLResponse,
             crate::rest_api::restart::RestartResponse,
+            crate::rest_api::status::StatusResponse,
+            crate::rest_api::status::RedisStatus,
+            crate::rest_api::status::LoggingStatus,
+            crate::rest_api::logs::LogsResponse,
+            crate::rest_api::logs::LogEntry,
+            crate::rest_api::config::UpdateConfigResponse,
+            crate::rest_api::config::ErrorResponse,
+            crate::rest_api::redis_check::RedisCheckRequest,
+            crate::rest_api::redis_check::RedisCheckResponse,
+            crate::lib::status::InputStatus,
+            crate::lib::status::DetectionStatus,
+            crate::lib::status::TrackingStatus,
+            crate::lib::logging::LoggedProblem,
             crate::rest_api::toml_mutations::ErrorResponse,
         ),
     )

--- a/src/rest_api/status.rs
+++ b/src/rest_api/status.rs
@@ -1,0 +1,97 @@
+use actix_web::{Error, HttpResponse, web};
+use serde::Serialize;
+use utoipa::ToSchema;
+
+use crate::lib::logging::{self, LoggedProblem};
+use crate::lib::status::{DetectionStatus, InputStatus, TrackingStatus};
+use crate::rest_api::APIStorage;
+use crate::settings::needs_restart;
+
+/// Where the statistics are published, without the password
+#[derive(Debug, Serialize, ToSchema)]
+pub struct RedisStatus {
+    pub enabled: bool,
+    pub host: String,
+    pub port: i32,
+    pub channel: String,
+}
+
+/// Where the log goes and how much of it
+#[derive(Debug, Serialize, ToSchema)]
+pub struct LoggingStatus {
+    /// "info" or "debug"
+    pub level: String,
+    /// Path of the log file, `null` when logging only to stdout
+    pub file: Option<String>,
+}
+
+/// Everything the application can say about itself right now
+#[derive(Debug, Serialize, ToSchema)]
+pub struct StatusResponse {
+    /// Identifies this installation point
+    pub equipment_id: String,
+    /// Version of the running binary
+    pub version: String,
+    /// Seconds since this process started. A restart resets it
+    pub uptime_seconds: u64,
+    pub input: InputStatus,
+    pub detection: DetectionStatus,
+    pub tracking: TrackingStatus,
+    pub redis: RedisStatus,
+    pub logging: LoggingStatus,
+    /// The last warning or error since start, `null` if there was none
+    pub last_problem: Option<LoggedProblem>,
+    /// Whether the saved configuration differs from the one this run started
+    /// with, i.e. whether `POST /api/mutations/restart` is due
+    pub restart_required: bool,
+    /// Dotted paths of the saved settings that are waiting for that restart
+    #[schema(example = json!(["input.video_src"]))]
+    pub pending_changes: Vec<String>,
+}
+
+#[utoipa::path(
+    get,
+    tag = "Application",
+    path = "/api/status",
+    responses(
+        (status = 200, description = "State of the running application", body = StatusResponse)
+    )
+)]
+/// Tells what the application is doing: which source it reads and whether
+/// frames are getting through, what it detects with, how it tracks, where it
+/// publishes and logs, and what went wrong last. Meant to answer the questions
+/// that would otherwise need an SSH session
+pub async fn status(data: web::Data<APIStorage>) -> Result<HttpResponse, Error> {
+    let settings = data
+        .app_settings
+        .read()
+        .expect("Settings are poisoned [RwLock]");
+    let verbose = settings.verbose.clone().unwrap_or_default();
+    let log_config = verbose.to_log_config(&data.settings_filename);
+    // A setting that applies live is not pending, but it is still a difference
+    // worth naming, so both are reported
+    let pending_changes = settings.differences_from(&data.running_settings);
+    Ok(HttpResponse::Ok().json(StatusResponse {
+        equipment_id: settings.equipment_info.id.clone(),
+        version: env!("CARGO_PKG_VERSION").to_string(),
+        uptime_seconds: data.status.uptime_seconds(),
+        input: data.status.input(),
+        detection: data.status.detection(),
+        tracking: data.status.tracking(),
+        redis: RedisStatus {
+            enabled: settings.redis_publisher.enable,
+            host: settings.redis_publisher.host.clone(),
+            port: settings.redis_publisher.port,
+            channel: settings.redis_publisher.channel_name.clone(),
+        },
+        logging: LoggingStatus {
+            level: log_config.level.to_string(),
+            file: log_config
+                .logs_folder
+                .map(|folder| folder.join(logging::LOG_FILE_NAME).display().to_string()),
+        },
+        last_problem: logging::last_problem(),
+        restart_required: pending_changes.iter().any(|path| needs_restart(path)),
+        pending_changes,
+    }))
+}

--- a/src/rest_api/toml_mutations.rs
+++ b/src/rest_api/toml_mutations.rs
@@ -42,7 +42,11 @@ pub async fn save_toml(data: web::Data<APIStorage>) -> Result<HttpResponse, Erro
         .zones
         .read()
         .expect("Spatial data is poisoned [RWLock]");
-    let mut setting_cloned = data.app_settings.get_copy_no_roads();
+    let mut setting_cloned = data
+        .app_settings
+        .read()
+        .expect("Settings are poisoned [RwLock]")
+        .get_copy_no_roads();
     let road_lanes = setting_cloned.road_lanes.get_or_insert_with(Vec::new);
     for (_, zone_guarded) in zones.iter() {
         let zone = zone_guarded.lock().expect("Zone is poisoned [Mutex]");

--- a/src/settings/settings.rs
+++ b/src/settings/settings.rs
@@ -108,11 +108,11 @@ impl VerboseSettings {
                 .parent()
                 .filter(|parent| !parent.as_os_str().is_empty())
                 .unwrap_or_else(|| std::path::Path::new("."));
-            Some(if folder.is_absolute() {
+            Some(tidy_path(if folder.is_absolute() {
                 folder.to_path_buf()
             } else {
                 base.join(folder)
-            })
+            }))
         };
         let max_file_size_mb = match self.max_file_size_mb {
             Some(mb) if mb > 0 => mb,
@@ -519,6 +519,82 @@ fn same_float(a: f64, b: f64) -> bool {
     (a - b).abs() <= f32::EPSILON as f64 * a.abs().max(1.0)
 }
 
+/// Drops the "." steps a joined path picks up, so that the path the app reports
+/// reads the way a person would write it. `..` is left alone: removing it would
+/// change which directory is meant whenever a symlink is involved
+fn tidy_path(path: std::path::PathBuf) -> std::path::PathBuf {
+    let tidy: std::path::PathBuf = path
+        .components()
+        .filter(|component| !matches!(component, std::path::Component::CurDir))
+        .collect();
+    if tidy.as_os_str().is_empty() {
+        std::path::PathBuf::from(".")
+    } else {
+        tidy
+    }
+}
+
+/// The settings key that holds the zones
+pub const ZONES_KEY: &str = "road_lanes";
+
+/// The only setting that takes effect without starting over. Everything else is
+/// read once, when the piece that uses it is built, so changing it is pending
+/// until a restart
+pub const LIVE_SETTINGS: [&str; 1] = ["verbose.level"];
+
+/// Whether a change of this setting is waiting for a restart to take effect
+pub fn needs_restart(path: &str) -> bool {
+    !LIVE_SETTINGS.contains(&path)
+}
+
+/// Dotted paths of the values that differ between the two, so that an answer
+/// can name what really changed rather than what was sent
+pub fn changed_paths(
+    before: &serde_json::Value,
+    after: &serde_json::Value,
+    prefix: &str,
+    out: &mut Vec<String>,
+) {
+    use serde_json::Value;
+    // A section absent from the file is null, and setting one key of it should
+    // read as that one key changing, not as the whole section appearing
+    let empty = Value::Object(serde_json::Map::new());
+    let before = match (before, after) {
+        (Value::Null, Value::Object(_)) => &empty,
+        (before, _) => before,
+    };
+    let after = match (before, after) {
+        (Value::Object(_), Value::Null) => &empty,
+        (_, after) => after,
+    };
+    match (before, after) {
+        (Value::Object(before), Value::Object(after)) => {
+            let mut keys: Vec<&String> = before.keys().chain(after.keys()).collect();
+            keys.sort();
+            keys.dedup();
+            for key in keys {
+                let path = if prefix.is_empty() {
+                    key.clone()
+                } else {
+                    format!("{prefix}.{key}")
+                };
+                let null = Value::Null;
+                changed_paths(
+                    before.get(key).unwrap_or(&null),
+                    after.get(key).unwrap_or(&null),
+                    &path,
+                    out,
+                );
+            }
+        }
+        (before, after) => {
+            if before != after {
+                out.push(prefix.to_string());
+            }
+        }
+    }
+}
+
 impl From<&RoadLanesSettings> for Zone {
     fn from(setting: &RoadLanesSettings) -> Self {
         let geom = setting
@@ -591,33 +667,84 @@ impl AppSettings {
             app_settings.tracking.kalman_filter = Some("centroid".to_string());
         }
 
-        // Validate tracker type
-        if let Some(ref typ) = app_settings.tracking.typ {
-            match typ.as_str() {
-                "iou_naive" | "bytetrack" => {}
-                _ => {
-                    return Err(SettingsError::Validation(format!(
-                        "Invalid tracker type: '{}'. Supported: 'iou_naive', 'bytetrack'.",
-                        typ
-                    )));
-                }
-            }
-        }
-
-        // Validate kalman filter type
-        if let Some(ref kf) = app_settings.tracking.kalman_filter {
-            match kf.as_str() {
-                "centroid" | "bbox" => {}
-                _ => {
-                    return Err(SettingsError::Validation(format!(
-                        "Invalid kalman filter type: '{}'. Supported: 'centroid', 'bbox'.",
-                        kf
-                    )));
-                }
-            }
-        }
-
+        app_settings.validate()?;
         Ok(app_settings)
+    }
+    /// Dotted paths of the settings that differ from `other`, e.g.
+    /// `input.video_src`. Zones are left out: they are edited through their own
+    /// endpoints and take effect at once, so they never mean anything is pending
+    pub fn differences_from(&self, other: &AppSettings) -> Vec<String> {
+        let (before, after) = match (serde_json::to_value(other), serde_json::to_value(self)) {
+            (Ok(before), Ok(after)) => (before, after),
+            _ => return Vec::new(),
+        };
+        let mut changed = Vec::new();
+        changed_paths(&before, &after, "", &mut changed);
+        changed.retain(|path| path != ZONES_KEY && !path.starts_with(&format!("{ZONES_KEY}.")));
+        changed
+    }
+
+    /// Checks the values that would otherwise only fail much later, when the
+    /// piece that reads them is built. Runs both on load and on every change
+    /// made through the API, so a file and a request are held to the same rules
+    pub fn validate(&self) -> Result<(), SettingsError> {
+        fn one_of(name: &str, value: &str, allowed: &[&str]) -> Result<(), SettingsError> {
+            if allowed.contains(&value) {
+                return Ok(());
+            }
+            Err(SettingsError::Validation(format!(
+                "Invalid {name}: '{value}'. Supported: {}",
+                allowed.join(", ")
+            )))
+        }
+        fn in_range<T: PartialOrd + std::fmt::Display>(
+            name: &str,
+            value: T,
+            low: T,
+            high: T,
+        ) -> Result<(), SettingsError> {
+            if value >= low && value <= high {
+                return Ok(());
+            }
+            Err(SettingsError::Validation(format!(
+                "{name} must be between {low} and {high}, got {value}"
+            )))
+        }
+
+        if let Some(typ) = self.tracking.typ.as_deref() {
+            one_of("tracker type", typ, &["iou_naive", "bytetrack"])?;
+        }
+        if let Some(kalman_filter) = self.tracking.kalman_filter.as_deref() {
+            one_of("kalman filter type", kalman_filter, &["centroid", "bbox"])?;
+        }
+        if let Some(level) = self.verbose.as_ref().and_then(|v| v.level.as_deref()) {
+            one_of("verbose level", level, &logging::LEVELS)?;
+        }
+        if self.input.video_src.trim().is_empty() {
+            return Err(SettingsError::Validation(
+                "video_src must not be empty".to_string(),
+            ));
+        }
+        if let Some(nth) = self.input.process_every_nth_frame {
+            in_range("process_every_nth_frame", nth, 1, 1000)?;
+        }
+        in_range("conf_threshold", self.detection.conf_threshold, 0.0, 1.0)?;
+        in_range("nms_threshold", self.detection.nms_threshold, 0.0, 1.0)?;
+        if let Some(iou) = self.tracking.iou_threshold {
+            in_range("iou_threshold", iou, 0.0, 1.0)?;
+        }
+        if let Some(seconds) = self.tracking.max_lost_seconds {
+            in_range("max_lost_seconds", seconds, 0.001, 3600.0)?;
+        }
+        in_range(
+            "reset_data_milliseconds",
+            self.worker.reset_data_milliseconds,
+            1,
+            24 * 60 * 60 * 1000,
+        )?;
+        in_range("back_end_port", self.rest_api.back_end_port, 1, 65535)?;
+        in_range("redis port", self.redis_publisher.port, 1, 65535)?;
+        Ok(())
     }
     /// Writes the settings back to `filename` keeping the file's comments, key
     /// order and formatting: every value this struct carries is set in the
@@ -947,7 +1074,7 @@ mod tests {
         assert_eq!(cfg.level, "info");
         assert_eq!(
             cfg.logs_folder.as_deref(),
-            Some(std::path::Path::new("/etc/rrt/./logs"))
+            Some(std::path::Path::new("/etc/rrt/logs"))
         );
         assert_eq!(cfg.max_file_size_bytes, 10 * 1024 * 1024);
         assert_eq!(cfg.max_files, 2);
@@ -979,5 +1106,64 @@ mod tests {
         );
         assert_eq!(cfg.max_file_size_bytes, 5 * 1024 * 1024);
         assert_eq!(cfg.max_files, 2);
+
+        // A folder next to a config given without a directory stays relative
+        let cfg = VerboseSettings {
+            logs_folder: Some("./logs".to_string()),
+            ..Default::default()
+        }
+        .to_log_config("conf.toml");
+        assert_eq!(
+            cfg.logs_folder.as_deref(),
+            Some(std::path::Path::new("logs"))
+        );
+    }
+
+    #[test]
+    fn changed_paths_are_dotted_and_only_for_real_changes() {
+        let before: serde_json::Value =
+            serde_json::from_str(r#"{"input":{"video_src":"a.mp4","nth":2},"worker":{"ms":30}}"#)
+                .unwrap();
+        let after: serde_json::Value =
+            serde_json::from_str(r#"{"input":{"video_src":"b.mp4","nth":2},"worker":{"ms":60}}"#)
+                .unwrap();
+        let mut changed = Vec::new();
+        changed_paths(&before, &after, "", &mut changed);
+        assert_eq!(changed, ["input.video_src", "worker.ms"]);
+
+        let mut unchanged = Vec::new();
+        changed_paths(&before, &before, "", &mut unchanged);
+        assert!(unchanged.is_empty());
+    }
+
+    #[test]
+    fn a_section_appearing_reports_only_its_keys() {
+        // The section was not in the file at all
+        let before: serde_json::Value = serde_json::from_str(r#"{"verbose":null}"#).unwrap();
+        let after: serde_json::Value =
+            serde_json::from_str(r#"{"verbose":{"level":"debug"}}"#).unwrap();
+        let mut changed = Vec::new();
+        changed_paths(&before, &after, "", &mut changed);
+        assert_eq!(changed, ["verbose.level"]);
+    }
+
+    #[test]
+    fn differences_ignore_the_zones() {
+        let file = TempConfig::new("differences");
+        let running = AppSettings::new(&file.0).unwrap();
+        let mut saved = running.clone();
+        assert!(saved.differences_from(&running).is_empty());
+
+        saved.input.video_src = "rtsp://cam/stream".to_string();
+        saved.road_lanes = Some(Vec::new());
+        assert_eq!(saved.differences_from(&running), ["input.video_src"]);
+    }
+
+    #[test]
+    fn only_the_log_level_applies_live() {
+        assert!(!needs_restart("verbose.level"));
+        assert!(needs_restart("verbose.logs_folder"));
+        assert!(needs_restart("input.video_src"));
+        assert!(needs_restart("tracking.type"));
     }
 }


### PR DESCRIPTION
Make API so allow to set more configuration options which in the past have could been changed only via manual TOML edit.

- `GET /api/status` - what is actually happening: the source and its real parameters, `processing_fps` and `frames_dropped`, inference backend and CUDA, per-frame timings, tracker, Redis, log file, and the last warning or error.
- `GET /api/logs` - the tail of the log file with `limit`, `level` and `scope` filters, reading into rotated files when the current one is not enough.
- `GET/PUT /api/config` - the single entry point for settings: a partial patch is validated the same way loading the file is, written to the config at once, and answered with what actually changed and whether a restart is due.
- `POST /api/redis/check` - connect and PING before saving a host.

Note: `config` API path says what is configured, `status` - says what is running, and the difference between them is the pending-restart indicator: `restart_required` and `pending_changes` in `status` outlive the answer to a `PUT`, so the UI still shows them after a reload